### PR TITLE
Fix test failures when using libc replacement functions

### DIFF
--- a/src/gotcha_utils.h
+++ b/src/gotcha_utils.h
@@ -98,4 +98,6 @@ do {                                                       \
   (void*)(((ElfW(Addr))ptr) & (-pagesize))
 
 
+int debug_print(struct link_map *libc, char *filter);
+
 #endif

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -12,6 +12,7 @@ ExternalProject_Add(
     INSTALL_COMMAND ""
     LOG_DOWNLOAD ON
 )
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../src)
 find_library(check NAME libcheck.a)
 add_executable(unit_tests gotcha_unit_tests.c)
 target_link_libraries(unit_tests check gotcha internal_unit_sample)

--- a/test/unit/gotcha_unit_tests.c
+++ b/test/unit/gotcha_unit_tests.c
@@ -26,12 +26,15 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 ////////////////////////////////////////////////////GOTCHA Core Tests///////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-struct tool* new_tool;
-void setup_infrastructure(){
-  new_tool = create_tool("internal_test_tool");
+tool_t* new_tool;
+void setup_infrastructure()
+{
+   if (!new_tool)
+      new_tool = create_tool("internal_test_tool");
 }
-void teardown_infrastructure(){
-  free(new_tool);
+
+void teardown_infrastructure()
+{
 }
 
 extern int gotcha_prepare_symbols(binding_t *bindings, int num_names);

--- a/test/unit/gotcha_unit_tests.c
+++ b/test/unit/gotcha_unit_tests.c
@@ -13,13 +13,14 @@ Public License along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
-#include <gotcha/gotcha.h>
 #include <link.h>
 #include <check.h>
+#include "gotcha/gotcha.h"
 #include "testing_lib.h"
-//#include <gotcha_utils.h>
-//#include "elf_ops.h"
-//#include "tool.h"
+#include "elf_ops.h"
+#include "tool.h"
+#include "libc_wrappers.h"
+#include "gotcha_utils.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////GOTCHA Core Tests///////////////////////////////////////////////////////////////////////////////////
@@ -32,6 +33,8 @@ void setup_infrastructure(){
 void teardown_infrastructure(){
   free(new_tool);
 }
+
+extern int gotcha_prepare_symbols(binding_t *bindings, int num_names);
 
 int dummy_main(int argc, char* argv[]){return 4;}
 START_TEST(symbol_prep_test)


### PR DESCRIPTION
The tests were calling internal gotcha functions without including the appropriate headers, which led to function signature mismatches and subsequent problems.