### PR TITLE
Check if C++11 is available before building hammer tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 option(GOTCHA_ENABLE_TESTS "Enable internal tests" Off)
 option(GOTCHA_ENABLE_COVERAGE_TESTS "Enable coverage tests" Off)
 project(gotcha)
+include(CheckCXXCompilerFlag)
+CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
 
 set(LIBTOOL_INTERFACE 0)
 set(LIBTOOL_REVISION 0)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,9 @@
+include(CheckCXXCompilerFlag)
 add_subdirectory(rogot)
 add_subdirectory(unit)
 add_subdirectory(dlopen)
+CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+if(COMPILER_SUPPORTS_CXX11)
 add_subdirectory(hammer)
+endif()
 


### PR DESCRIPTION
Should fix build breaking with older gcc