### PR TITLE
[RFC] Moderate intermediate interface change

### DIFF
--- a/include/gotcha/gotcha.h
+++ b/include/gotcha/gotcha.h
@@ -71,6 +71,20 @@ extern "C" {
 
 GOTCHA_EXPORT enum gotcha_error_t gotcha_wrap(struct gotcha_binding_t* bindings, int num_actions, const char* tool_name);
 
+/*!
+ ******************************************************************************
+ *
+ * \fn enum void* gotcha_get_wrapped_function(wrapper_id_t wrappee)
+ *
+ * \brief Returns the underlying function for use in Gotcha wrappers
+ *
+ * \param wrappee The index of the underlying function the user desires
+ *
+ ******************************************************************************
+ */
+
+GOTCHA_EXPORT void* gotcha_get_wrapped_function(wrapper_id_t wrappee); 
+
 #if defined(__cplusplus) 
 }
 #endif

--- a/include/gotcha/gotcha_types.h
+++ b/include/gotcha/gotcha_types.h
@@ -28,6 +28,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 extern "C" {
 #endif
 
+typedef void* wrapper_id_t;
+
 /*!
  * The representation of a GOTCHA action
  * as it passes through the pipeline
@@ -35,7 +37,7 @@ extern "C" {
 struct gotcha_binding_t {
   const char* name;                      //!< The name of the function being wrapped
   void* wrapper_pointer;           //!< A pointer to the wrapper function
-  void* function_address_pointer;  //!< A pointer to the function being wrapped
+  wrapper_id_t function_address_pointer;  //!< A pointer to the function being wrapped
 };
 
 /*!

--- a/src/gotcha.c
+++ b/src/gotcha.c
@@ -204,3 +204,7 @@ GOTCHA_EXPORT enum gotcha_error_t gotcha_wrap(struct gotcha_binding_t* user_bind
   debug_printf(1, "Returning code %d from gotcha_wrap\n", ret_code);
   return ret_code;
 }
+
+void* gotcha_get_wrapped_function(wrapper_id_t wrappee){
+  return wrappee;
+}


### PR DESCRIPTION
@mplegendre : I realized that at the end of the day, the user-facing side of the interface will need to have one change: the way in which a user "asks for" the underlying function pointer. My idea here is to propose that we start socializing that, I imagine whatever implementation we wind up with will have to honor essentially this contract, just with varying meanings of "wrapper_id_t" and "gotcha_get_wrapped_function." If you are okay with this idea, before merging I'll update our examples to match this.

The problem (I know about):

Before, you would do something like


```
int (*my_wrappee)();

int my_wrapper(){ return my_wrappee() + 5;}

struct gotcha_binding_t gotcha_actions[] = {
  {"wrap_this",my_wrapper,(void**)&my_wrappee} //optional casting
};
```

The new interface is going to be much uglier, as "my_wrappee" isn't the actual function pointer, you'll need something like

```
wrapper_id_t my_wrappee_index;
int my_wrapper(){
   return (int(*)())gotcha_get_wrapped_function(my_wrappee_index) + 5;
}
```

Which I think is just a fact of life, but it is ugly as user-facing code can be.

Thoughts?