### PR TITLE
Restructure multitool binding code

### DIFF
--- a/include/gotcha/gotcha.h
+++ b/include/gotcha/gotcha.h
@@ -82,12 +82,28 @@ GOTCHA_EXPORT enum gotcha_error_t gotcha_wrap(struct gotcha_binding_t* bindings,
  *        wrappings over the same functions.
  *
  * \param tool_name   The tool name to set the priority of
- * \param num_actions The new priority value for the tool.  Lower values
+ * \param priority    The new priority value for the tool.  Lower values
  *                    are stacked intermost.
  *
  ******************************************************************************
  */
-GOTCHA_EXPORT enum gotcha_error_t gotcha_set_priority(const char* tool_name, int value);
+GOTCHA_EXPORT enum gotcha_error_t gotcha_set_priority(const char* tool_name, int priority);
+
+/*!
+ ******************************************************************************
+ *
+ * \fn enum gotcha_error_t gotcha_get_priority(const char *tool_name,
+ *                                             int *value);
+ *
+ * \brief Gets the tool priority, which controls how multiple tools stack
+ *        wrappings over the same functions.
+ *
+ * \param tool_name   The tool name to get the priority of
+ * \param num_actions Output parameters with the priority for the tool.
+ *
+ ******************************************************************************
+ */
+GOTCHA_EXPORT enum gotcha_error_t gotcha_get_priority(const char* tool_name, int *priority);
 
 #if defined(__cplusplus) 
 }

--- a/include/gotcha/gotcha.h
+++ b/include/gotcha/gotcha.h
@@ -71,11 +71,23 @@ extern "C" {
 
 GOTCHA_EXPORT enum gotcha_error_t gotcha_wrap(struct gotcha_binding_t* bindings, int num_actions, const char* tool_name);
 
-//GOTCHA_EXPORT enum gotcha_error_t gotcha_configure_int(const char* tool_name, enum gotcha_config_key_t configuration_key , int value);
-//GOTCHA_EXPORT enum gotcha_error_t gotcha_configure_float(const char* tool_name, enum gotcha_config_key_t configuration_key , float value);
-//GOTCHA_EXPORT enum gotcha_error_t gotcha_configure_string(const char* tool_name, enum gotcha_config_key_t configuration_key , const char* value);
-GOTCHA_EXPORT enum gotcha_error_t gotcha_set_priority(const char* tool_name, int value);
 
+/*!
+ ******************************************************************************
+ *
+ * \fn enum gotcha_error_t gotcha_set_priority(const char *tool_name,
+ *                                             int value);
+ *
+ * \brief Set the tool priority, which controls how multiple tools stack
+ *        wrappings over the same functions.
+ *
+ * \param tool_name   The tool name to set the priority of
+ * \param num_actions The new priority value for the tool.  Lower values
+ *                    are stacked intermost.
+ *
+ ******************************************************************************
+ */
+GOTCHA_EXPORT enum gotcha_error_t gotcha_set_priority(const char* tool_name, int value);
 
 #if defined(__cplusplus) 
 }

--- a/include/gotcha/gotcha.h
+++ b/include/gotcha/gotcha.h
@@ -83,7 +83,7 @@ GOTCHA_EXPORT enum gotcha_error_t gotcha_wrap(struct gotcha_binding_t* bindings,
  *
  * \param tool_name   The tool name to set the priority of
  * \param priority    The new priority value for the tool.  Lower values
- *                    are stacked intermost.
+ *                    are called innermost.
  *
  ******************************************************************************
  */

--- a/include/gotcha/gotcha_types.h
+++ b/include/gotcha/gotcha_types.h
@@ -46,7 +46,7 @@ enum gotcha_error_t {
   GOTCHA_SUCCESS = 0,          //!< The call succeeded
   GOTCHA_FUNCTION_NOT_FOUND,   //!< The call looked up a function which could not be found
   GOTCHA_INTERNAL,             //!< Internal gotcha error
-  GOTCHA_INVALID_CONFIGURATION //!< Failure on a configuration call
+  GOTCHA_INVALID_TOOL          //!< Invalid tool name
 };
 
 #if defined(__cplusplus) 

--- a/include/gotcha/gotcha_types.h
+++ b/include/gotcha/gotcha_types.h
@@ -49,10 +49,6 @@ enum gotcha_error_t {
   GOTCHA_INVALID_CONFIGURATION //!< Failure on a configuration call
 };
 
-enum gotcha_config_key_t {
-  GOTCHA_PRIORITY
-};
-
 #if defined(__cplusplus) 
 }
 #endif

--- a/src/gotcha.c
+++ b/src/gotcha.c
@@ -104,13 +104,13 @@ static void gotcha_rewrite_wrapper_orders(struct internal_binding_t* binding){
   struct internal_binding_t* head;
   int hash_result;
   const char* name = binding->user_binding->name;
-  int insert_priority = gotcha_get_priority(binding->associated_binding_table->tool->tool_name);
+  int insert_priority = get_priority(binding->associated_binding_table->tool);
   hash_result = lookup_hashtable(function_hash_table, (void*)name, (void**)&head);
   if(hash_result != 0){
     debug_printf(1,"Rewriting wrapper on an unknown function");
   }
   else{
-    int priority = gotcha_get_priority(head->associated_binding_table->tool->tool_name);
+    int priority = get_priority(head->associated_binding_table->tool);
     if(priority < insert_priority){ // if I'm the new head of the list of calls
       binding->next_binding = head;
       (*(void**)binding->user_binding->function_address_pointer) = head->user_binding->wrapper_pointer;
@@ -118,7 +118,7 @@ static void gotcha_rewrite_wrapper_orders(struct internal_binding_t* binding){
       addto_hashtable(function_hash_table, (void*)name, (void*)binding);
     }
     else{
-      while((head->next_binding) && (gotcha_get_priority(head->next_binding->associated_binding_table->tool->tool_name) >= insert_priority) ){
+      while((head->next_binding) && (get_priority(head->next_binding->associated_binding_table->tool) >= insert_priority) ){
         if(head->user_binding->wrapper_pointer==binding->user_binding->wrapper_pointer){
           return;
         }
@@ -140,7 +140,7 @@ static void gotcha_rewrite_got(struct internal_binding_t* binding,  void** got_e
   struct internal_binding_t* head;
   int hash_result;
   const char* name = binding->user_binding->name;
-  int insert_priority = gotcha_get_priority(binding->associated_binding_table->tool->tool_name);
+  int insert_priority = get_priority(binding->associated_binding_table->tool);
   hash_result = lookup_hashtable(function_hash_table, (void*)name, (void**)&head);
   if(hash_result != 0){
     addto_hashtable(function_hash_table, (void*)name, (void*)binding);
@@ -148,7 +148,7 @@ static void gotcha_rewrite_got(struct internal_binding_t* binding,  void** got_e
     binding->is_rewritten = 1;
   }
   else{
-    int priority = gotcha_get_priority(head->associated_binding_table->tool->tool_name);
+    int priority = get_priority(head->associated_binding_table->tool);
     if(priority < insert_priority){ // if I'm the new head of the list of calls
       writeAddress(got_entry, binding->user_binding->wrapper_pointer);
     }
@@ -281,3 +281,8 @@ GOTCHA_EXPORT enum gotcha_error_t gotcha_set_priority(const char* tool_name, int
   reorder_tool(tool_to_place);
   return GOTCHA_SUCCESS;
 }
+
+GOTCHA_EXPORT enum gotcha_error_t gotcha_get_priority(const char* tool_name, int *priority){
+  return get_configuration_value(tool_name, GOTCHA_PRIORITY, priority);
+}
+

--- a/src/gotcha.c
+++ b/src/gotcha.c
@@ -94,8 +94,8 @@ static void insert_at_head(struct internal_binding_t *binding, struct internal_b
 {
    binding->next_binding = head;
    (*(void**)binding->user_binding->function_address_pointer) = head->user_binding->wrapper_pointer;
-   removefrom_hashtable(function_hash_table, (void*) binding->user_binding->name);
-   addto_hashtable(function_hash_table, (void*)binding->user_binding->name, (void*)binding);
+   removefrom_hashtable(&function_hash_table, (void*) binding->user_binding->name);
+   addto_hashtable(&function_hash_table, (void*)binding->user_binding->name, (void*)binding);
 }
 
 static void insert_after_pos(struct internal_binding_t *binding, struct internal_binding_t *pos)
@@ -119,10 +119,10 @@ static int rewrite_wrapper_orders(struct internal_binding_t* binding)
 
   struct internal_binding_t* head;
   int hash_result;
-  hash_result = lookup_hashtable(function_hash_table, (void*)name, (void**)&head);
+  hash_result = lookup_hashtable(&function_hash_table, (void*)name, (void**)&head);
   if(hash_result != 0) {
     debug_printf(2, "Adding new entry for %s to hash table\n", name);
-    addto_hashtable(function_hash_table, (void *) name, (void *) binding);
+    addto_hashtable(&function_hash_table, (void *) name, (void *) binding);
     return (RWO_NEED_LOOKUP | RWO_NEED_BINDING);
   }
 

--- a/src/gotcha.c
+++ b/src/gotcha.c
@@ -239,7 +239,7 @@ static int update_library_got(struct link_map *map, hash_table_t *bindingtable)
 void update_all_library_gots(hash_table_t *bindings)
 {
    struct link_map *lib_iter;
-   debug_printf(2, "Searching all callsites for %d bindings\n", bindings->entry_count);
+   debug_printf(2, "Searching all callsites for %lu bindings\n", (unsigned long) bindings->entry_count);
    for (lib_iter = _r_debug.r_map; lib_iter != 0; lib_iter = lib_iter->l_next) {
       update_library_got(lib_iter, bindings);
    }   

--- a/src/gotcha.c
+++ b/src/gotcha.c
@@ -33,7 +33,7 @@ static void setBindingAddressPointer(struct gotcha_binding_t* in, void* value){
   writeAddress(getBindingAddressPointer(in), value);
 }
 
-int gotcha_prepare_symbols(binding_t *bindings, int num_names) {
+static int gotcha_prepare_symbols(binding_t *bindings, int num_names) {
   struct link_map *lib;
   struct gotcha_binding_t *binding_iter;
   signed long result;
@@ -95,7 +95,8 @@ int gotcha_prepare_symbols(binding_t *bindings, int num_names) {
                found, num_names);
   return 0;
 }
-void gotcha_rewrite_wrapper_orders(struct internal_binding_t* binding){
+
+static void gotcha_rewrite_wrapper_orders(struct internal_binding_t* binding){
   if(binding->is_rewritten){
     binding->is_rewritten = 0;
     return;
@@ -134,7 +135,8 @@ void gotcha_rewrite_wrapper_orders(struct internal_binding_t* binding){
     }
   }
 }
-void gotcha_rewrite_got(struct internal_binding_t* binding,  void** got_entry){
+
+static void gotcha_rewrite_got(struct internal_binding_t* binding,  void** got_entry){
   struct internal_binding_t* head;
   int hash_result;
   const char* name = binding->user_binding->name;
@@ -152,8 +154,9 @@ void gotcha_rewrite_got(struct internal_binding_t* binding,  void** got_entry){
     }
   }
 }
-int gotcha_wrap_impl(ElfW(Sym) * symbol KNOWN_UNUSED, char *name, ElfW(Addr) offset,
-                     struct link_map *lmap, binding_t *bindings) {
+
+static int gotcha_wrap_impl(ElfW(Sym) * symbol KNOWN_UNUSED, char *name, ElfW(Addr) offset,
+                            struct link_map *lmap, binding_t *bindings) {
   int result;
   binding_ref_t *ref;
   struct internal_binding_t *internal_binding;
@@ -181,8 +184,7 @@ GOTCHA_EXPORT enum gotcha_error_t gotcha_wrap(struct gotcha_binding_t* user_bind
 
   gotcha_init();
 
-  //First we rewrite anything being wrapped to NULL, so that we can recognize unfound entries
-   
+  //First we rewrite anything being wrapped to NULL, so that we can recognize unfound entries   
   for (i = 0; i < num_actions; i++) {
     setBindingAddressPointer(&user_bindings[i], NULL);
   }
@@ -250,7 +252,7 @@ GOTCHA_EXPORT enum gotcha_error_t gotcha_wrap(struct gotcha_binding_t* user_bind
   return ret_code;
 }
 
-enum gotcha_error_t gotcha_configure_int(const char* tool_name, enum gotcha_config_key_t configuration_key , int value){
+static enum gotcha_error_t gotcha_configure_int(const char* tool_name, enum gotcha_config_key_t configuration_key , int value){
   tool_t * tool = get_tool(tool_name);
   if(tool==NULL){
     tool = create_tool(tool_name);

--- a/src/gotcha.c
+++ b/src/gotcha.c
@@ -191,7 +191,7 @@ static int mark_got_writable(struct link_map *lib)
    if (!page_size)
       page_size = gotcha_getpagesize();
 
-   size_t protect_size = MAX(rel_count * rel_size, page_size);
+   size_t protect_size = MAX(rel_size, page_size);
    if(protect_size % page_size){
       protect_size += page_size -  ((protect_size) %page_size);
    }
@@ -201,7 +201,7 @@ static int mark_got_writable(struct link_map *lib)
    int res = gotcha_mprotect((void*)prot_address,protect_size,PROT_READ | PROT_WRITE | PROT_EXEC );
    if(res == -1){ // mprotect returns -1 on an error
       error_printf("GOTCHA attempted to mark the GOT table as writable and was unable to do so, "
-                   "calls to wrapped functions may likely fail\n");
+                   "calls to wrapped functions may likely fail.\n");
    }
 
    return 0;

--- a/src/gotcha.c
+++ b/src/gotcha.c
@@ -38,7 +38,7 @@ int gotcha_prepare_symbols(binding_t *bindings, int num_names) {
   struct gotcha_binding_t *binding_iter;
   signed long result;
   int found = 0, not_found = 0;
-  struct gotcha_binding_t *user_bindings = bindings->user_binding->user_binding;
+  struct gotcha_binding_t *user_bindings = bindings->internal_bindings->user_binding;
   debug_printf(1, "Looking up exported symbols for %d table entries\n", num_names);
   for (lib = _r_debug.r_map; lib != 0; lib = lib->l_next) {
     if (is_vdso(lib)) {
@@ -160,7 +160,7 @@ int gotcha_wrap_impl(ElfW(Sym) * symbol KNOWN_UNUSED, char *name, ElfW(Addr) off
   result = lookup_hashtable(&bindings->binding_hash, name, (void **) &ref);
   if (result != 0)
      return 0;
-  internal_binding = ((struct internal_binding_t*)(ref->binding->user_binding + ref->index));
+  internal_binding = ((struct internal_binding_t*)(ref->binding->internal_bindings + ref->index));
   gotcha_rewrite_got(internal_binding, (void**)(lmap->l_addr + offset));
   debug_printf(3, "Remapped call to %s at 0x%lx in %s to wrapper at 0x%p on INDEX\n",
              name, (lmap->l_addr + offset), LIB_NAME(lmap), 
@@ -236,7 +236,7 @@ GOTCHA_EXPORT enum gotcha_error_t gotcha_wrap(struct gotcha_binding_t* user_bind
   }
   int binding_iter; 
   for(binding_iter = 0; binding_iter < num_actions; binding_iter++){
-    gotcha_rewrite_wrapper_orders(&bindings->user_binding[binding_iter]);
+    gotcha_rewrite_wrapper_orders(&bindings->internal_bindings[binding_iter]);
   }
   ret_code = GOTCHA_SUCCESS;
   for(i = 0; i<num_actions;i++){

--- a/src/gotcha.c
+++ b/src/gotcha.c
@@ -261,8 +261,8 @@ static enum gotcha_error_t gotcha_configure_int(const char* tool_name, enum gotc
     tool->config.priority = value;
   }
   else{
-    debug_printf(1, "Invalid property being configured on tool %s\n", tool_name);
-    return GOTCHA_INVALID_CONFIGURATION;
+    error_printf("Invalid property being configured on tool %s\n", tool_name);
+    return GOTCHA_INTERNAL;
   }
   return GOTCHA_SUCCESS;
 }
@@ -270,8 +270,7 @@ static enum gotcha_error_t gotcha_configure_int(const char* tool_name, enum gotc
 GOTCHA_EXPORT enum gotcha_error_t gotcha_set_priority(const char* tool_name, int value){
   enum gotcha_error_t error_on_set = gotcha_configure_int(tool_name, GOTCHA_PRIORITY, value);
   if(error_on_set != GOTCHA_SUCCESS) {
-    debug_printf(1, "Failed to set priority on tool %s\n", tool_name);
-    return GOTCHA_INVALID_CONFIGURATION;
+    return error_on_set;
   }
   tool_t* tool_to_place = get_tool(tool_name);
   if(!tool_to_place){

--- a/src/gotcha_dl.c
+++ b/src/gotcha_dl.c
@@ -33,7 +33,7 @@ static void free_reverse_iterator(struct rev_iter* free_me){
   }
 }
 
-static int per_binding(hash_key_t key, hash_data_t data, void *opaque)
+static int per_binding(hash_key_t key, hash_data_t data, void *opaque KNOWN_UNUSED)
 {
    int result;
    struct internal_binding_t *binding = (struct internal_binding_t *) data;

--- a/src/gotcha_dl.c
+++ b/src/gotcha_dl.c
@@ -9,7 +9,8 @@ void* _dl_sym(void* handle, const char* name, void* where);
 
 static void*(*orig_dlopen)(const char* filename, int flags);
 static void*(*orig_dlsym)(void* handle, const char* name);
-struct rev_iter* get_reverse_tool_iterator(struct binding_t* in){
+
+static struct rev_iter* get_reverse_tool_iterator(struct binding_t* in){
   struct rev_iter* rev_builder = (struct rev_iter*)malloc(sizeof(struct rev_iter));
   rev_builder->next = NULL;
   struct rev_iter* rever;
@@ -22,7 +23,8 @@ struct rev_iter* get_reverse_tool_iterator(struct binding_t* in){
   }
   return rev_builder;
 }
-void free_reverse_iterator(struct rev_iter* free_me){
+
+static void free_reverse_iterator(struct rev_iter* free_me){
   struct rev_iter* next;
   while(free_me){
     next = free_me->next;
@@ -30,7 +32,8 @@ void free_reverse_iterator(struct rev_iter* free_me){
     free_me = next;
   }
 }
-void* dlopen_wrapper(const char* filename, int flags){
+
+static void* dlopen_wrapper(const char* filename, int flags){
   void* handle = orig_dlopen(filename,flags);
   struct binding_t* tool_iter = get_bindings();
   /**
@@ -43,7 +46,8 @@ void* dlopen_wrapper(const char* filename, int flags){
   restoreLibraryFilterFunc();
   return handle;
 }
-void* dlsym_wrapper(void* handle, const char* symbol_name){
+
+static void* dlsym_wrapper(void* handle, const char* symbol_name){
   if(handle == RTLD_NEXT){
     return _dl_sym(RTLD_NEXT, symbol_name ,__builtin_return_address(0));
   }
@@ -73,4 +77,4 @@ void handle_libdl(){
   };     
   gotcha_wrap(dl_binds, 2, "gotcha");
 }
-#undef _GNU_SOURCE
+

--- a/src/gotcha_dl.c
+++ b/src/gotcha_dl.c
@@ -11,13 +11,13 @@ static void*(*orig_dlopen)(const char* filename, int flags);
 static void*(*orig_dlsym)(void* handle, const char* name);
 
 static struct rev_iter* get_reverse_tool_iterator(struct binding_t* in){
-  struct rev_iter* rev_builder = (struct rev_iter*)malloc(sizeof(struct rev_iter));
+  struct rev_iter* rev_builder = (struct rev_iter*) gotcha_malloc(sizeof(struct rev_iter));
   rev_builder->next = NULL;
   struct rev_iter* rever;
   struct binding_t* tool_iter = in;
   for(;tool_iter!=NULL;tool_iter = tool_iter->next_binding){
     rev_builder->data = tool_iter;
-    rever =  (struct rev_iter*)malloc(sizeof(struct rev_iter));
+    rever =  (struct rev_iter*) gotcha_malloc(sizeof(struct rev_iter));
     rever->next = rev_builder;
     rev_builder = rever;
   }
@@ -28,7 +28,7 @@ static void free_reverse_iterator(struct rev_iter* free_me){
   struct rev_iter* next;
   while(free_me){
     next = free_me->next;
-    free(free_me);
+    gotcha_free(free_me);
     free_me = next;
   }
 }

--- a/src/gotcha_dl.c
+++ b/src/gotcha_dl.c
@@ -38,7 +38,7 @@ void* dlopen_wrapper(const char* filename, int flags){
    */
   onlyFilterLast();
   for(;tool_iter!=NULL;tool_iter = tool_iter->next_binding){
-      gotcha_wrap(tool_iter->user_binding->user_binding,tool_iter->user_binding_size,tool_iter->tool->tool_name);
+      gotcha_wrap(tool_iter->internal_bindings->user_binding,tool_iter->internal_bindings_size,tool_iter->tool->tool_name);
   }
   restoreLibraryFilterFunc();
   return handle;
@@ -54,10 +54,10 @@ void* dlsym_wrapper(void* handle, const char* symbol_name){
     struct binding_t* tool_iter = rev->data;
     if(tool_iter){
       int loop = 0;
-      for(loop=0;loop<tool_iter->user_binding_size;loop++){
-        if(gotcha_strcmp(tool_iter->user_binding->user_binding[loop].name,symbol_name)==0){
+      for(loop=0;loop<tool_iter->internal_bindings_size;loop++){
+        if(gotcha_strcmp(tool_iter->internal_bindings->user_binding[loop].name,symbol_name)==0){
           free_reverse_iterator(rev);
-          return tool_iter->user_binding->user_binding[loop].wrapper_pointer;
+          return tool_iter->internal_bindings->user_binding[loop].wrapper_pointer;
         }
       }
     }

--- a/src/gotcha_dl.h
+++ b/src/gotcha_dl.h
@@ -1,6 +1,11 @@
 #ifndef GOTCHA_DL_H
 #define GOTCHA_DL_H
 
+#include "hash.h"
+#include "tool.h"
+
 void handle_libdl();
+extern void update_all_library_gots(hash_table_t *bindings);
+extern int prepare_symbol(struct internal_binding_t *binding);
 
 #endif

--- a/src/gotcha_dl.h
+++ b/src/gotcha_dl.h
@@ -1,6 +1,6 @@
 #ifndef GOTCHA_DL_H
 #define GOTCHA_DL_H
-void* dlopen_wrapper(const char* filename, int flags);
-void* dlsym_wrapper(void* handle, const char* symbol_name);
+
 void handle_libdl();
+
 #endif

--- a/src/gotcha_utils.c
+++ b/src/gotcha_utils.c
@@ -46,9 +46,69 @@ static void debug_init()
 }
 
 hash_table_t function_hash_table;
+hash_table_t notfound_binding_table;
 
-static void setup_function_hash_table(){
-  create_hashtable(&function_hash_table, 4096, (hash_func_t)strhash, (hash_cmp_t) gotcha_strcmp); 
+static hash_table_t library_table;
+static library_t *library_list = NULL;
+unsigned int current_generation;
+
+static hash_hashvalue_t link_map_hash(struct link_map *map)
+{
+   hash_hashvalue_t hashval = (hash_hashvalue_t) ((unsigned long) map);
+   hashval ^= strhash(LIB_NAME(map));
+   return hashval;
+}
+
+static int link_map_cmp(struct link_map *a, struct link_map *b)
+{
+   return ((unsigned long) a) < ((unsigned long) b);
+}
+
+static void setup_hash_tables() {
+   create_hashtable(&library_table, 128, (hash_func_t) link_map_hash, (hash_cmp_t) link_map_cmp);
+   create_hashtable(&function_hash_table, 4096, (hash_func_t) strhash, (hash_cmp_t) gotcha_strcmp);
+   create_hashtable(&notfound_binding_table, 128, (hash_func_t) strhash, (hash_cmp_t) gotcha_strcmp);    
+}
+
+struct library_t *get_library(struct link_map *map)
+{
+   library_t *lib;
+   int result;
+   result = lookup_hashtable(&library_table, (hash_key_t) map, (hash_data_t *) &lib);
+   if (result == -1)
+      return NULL;
+   return lib;
+}
+
+struct library_t *add_library(struct link_map *map)
+{
+   library_t *newlib = gotcha_malloc(sizeof(library_t));
+   newlib->map = map;
+   newlib->flags = 0;
+   newlib->generation = 0;
+   newlib->next = library_list;
+   newlib->prev = NULL;
+   if (library_list)
+      library_list->prev = newlib;
+   library_list = newlib;
+   addto_hashtable(&library_table, (hash_key_t) map, (hash_data_t) newlib);
+   return newlib;
+}
+
+void remove_library(struct link_map *map)
+{
+   library_t *lib = get_library(map);
+   if (!lib)
+      return;
+   if (lib->prev)
+      lib->prev->next = lib->next;
+   if (lib->next)
+      lib->next->prev = lib->prev;
+   if (lib == library_list)
+      library_list = library_list->next;
+   removefrom_hashtable(&library_table, (hash_key_t) map);
+   memset(lib, 0, sizeof(library_t));
+   gotcha_free(lib);
 }
 
 void gotcha_init(){
@@ -57,8 +117,8 @@ void gotcha_init(){
      return;
    }
    gotcha_initialized = 1;
-   setup_function_hash_table();
    debug_init();
+   setup_hash_tables();
    handle_libdl();
 }
 

--- a/src/gotcha_utils.c
+++ b/src/gotcha_utils.c
@@ -22,24 +22,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 #include <stdlib.h>
 #include "hash.h"
 
-int debug_print_impl(ElfW(Sym) * symbol, char *name, ElfW(Addr) offset,
-                     char *filter)
-{
-  if (gotcha_strstr(name, filter)) {
-     debug_printf(1, "Symbol name: %s, offset %lu, size %lu\n", name, offset,
-                  symbol->st_size);
-  }
-  return 0;
-}
-
-int debug_print(struct link_map *libc, char *filter)
-{
-  FOR_EACH_PLTREL(libc, debug_print_impl, filter);
-  return 0;
-}
-
 int debug_level;
-void debug_init()
+static void debug_init()
 {
    static int debug_initialized = 0;
 
@@ -61,7 +45,7 @@ void debug_init()
    debug_printf(0, "Gotcha debug initialized at level %d\n", debug_level);
 }
 
-void setup_function_hash_table(){
+static void setup_function_hash_table(){
   function_hash_table = (hash_table_t*)malloc(sizeof(hash_table_t));
   create_hashtable(function_hash_table, 4096, (hash_func_t)strhash, (hash_cmp_t) gotcha_strcmp); 
 }

--- a/src/gotcha_utils.c
+++ b/src/gotcha_utils.c
@@ -45,9 +45,10 @@ static void debug_init()
    debug_printf(0, "Gotcha debug initialized at level %d\n", debug_level);
 }
 
+hash_table_t function_hash_table;
+
 static void setup_function_hash_table(){
-  function_hash_table = (hash_table_t*)malloc(sizeof(hash_table_t));
-  create_hashtable(function_hash_table, 4096, (hash_func_t)strhash, (hash_cmp_t) gotcha_strcmp); 
+  create_hashtable(&function_hash_table, 4096, (hash_func_t)strhash, (hash_cmp_t) gotcha_strcmp); 
 }
 
 void gotcha_init(){

--- a/src/gotcha_utils.h
+++ b/src/gotcha_utils.h
@@ -42,11 +42,8 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 
 #define GOTCHA_DEBUG_ENV "GOTCHA_DEBUG"
 extern int debug_level;
-void debug_init();
 void gotcha_init();
 hash_table_t* function_hash_table;
-
-void setup_function_hash_table();
 
 #define debug_bare_printf(lvl, format, ...)       \
    do {                                           \
@@ -108,8 +105,5 @@ struct rev_iter{
   struct binding_t* data;
   void* next;
 };
-
-int debug_print(struct link_map *libc, char *filter);
-
 
 #endif

--- a/src/gotcha_utils.h
+++ b/src/gotcha_utils.h
@@ -43,7 +43,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 extern int debug_level;
 void gotcha_init();
 extern hash_table_t function_hash_table;
-
+extern hash_table_t notfound_binding_table;
 #define debug_bare_printf(lvl, format, ...)       \
    do {                                           \
      if (debug_level >= lvl) {                    \

--- a/src/gotcha_utils.h
+++ b/src/gotcha_utils.h
@@ -32,7 +32,6 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <assert.h>
 // END TODO
 #include <elf.h>
 #include <link.h>
@@ -43,7 +42,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #define GOTCHA_DEBUG_ENV "GOTCHA_DEBUG"
 extern int debug_level;
 void gotcha_init();
-hash_table_t* function_hash_table;
+extern hash_table_t function_hash_table;
 
 #define debug_bare_printf(lvl, format, ...)       \
    do {                                           \

--- a/src/gotcha_utils.h
+++ b/src/gotcha_utils.h
@@ -100,9 +100,4 @@ do {                                                       \
   (ElfW(Addr))(((ElfW(Addr))ptr) &(-pagesize))
 
 
-struct rev_iter{
-  struct binding_t* data;
-  void* next;
-};
-
 #endif

--- a/src/hash.c
+++ b/src/hash.c
@@ -24,6 +24,8 @@ struct hash_entry_t {
    hash_key_t key;
    hash_data_t data;
    hash_hashvalue_t hash_value;
+   struct hash_entry_t *next;
+   struct hash_entry_t *prev;
    uint32_t status;
 };
 
@@ -39,7 +41,6 @@ int create_hashtable(hash_table_t *table, size_t initial_size, hash_func_t hashf
    if (initial_size % entries_per_page)
       initial_size += entries_per_page - (initial_size % entries_per_page);
 
-   // TODO: ensure free
    newtable = (hash_entry_t *) gotcha_malloc(initial_size * sizeof(hash_entry_t));
    if (!newtable)
       return -1;
@@ -50,11 +51,12 @@ int create_hashtable(hash_table_t *table, size_t initial_size, hash_func_t hashf
    table->hashfunc = hashfunc;
    table->keycmp = keycmp;
    table->table = newtable;
+   table->head = NULL;
    
    return 0;
 }
 
-static int insert(hash_table_t *table, hash_key_t key, hash_data_t data, hash_hashvalue_t value)
+static hash_entry_t *insert(hash_table_t *table, hash_key_t key, hash_data_t data, hash_hashvalue_t value)
 {
    unsigned long index = (unsigned long)value % table->table_size;
    unsigned long startindex = index;
@@ -66,20 +68,19 @@ static int insert(hash_table_t *table, hash_key_t key, hash_data_t data, hash_ha
          entry->data = data;
          entry->hash_value = value;
          entry->status = INUSE;
-         table->entry_count++;
-         return 0;
+         return entry;
       }
       index++;
       if (index == table->table_size)
          index = 0;
    } while (index != startindex);
-   return -1;
+   return NULL;
 }
 
 int grow_hashtable(hash_table_t *table, size_t new_size)
 {
    hash_table_t newtable;
-   int result;
+   hash_entry_t *result;
    size_t i;
 
    newtable.table_size = new_size;
@@ -94,7 +95,7 @@ int grow_hashtable(hash_table_t *table, size_t new_size)
          continue;
       result = insert(&newtable, table->table[i].key, table->table[i].data,
                       table->table[i].hash_value);
-      if (result == -1) {
+      if (!result) {
          return -1;
       }
    }
@@ -112,6 +113,7 @@ int destroy_hashtable(hash_table_t *table)
    table->hashfunc = NULL;
    table->keycmp = NULL;
    table->table = NULL;
+   table->head = NULL;
    return 0;
 }
 
@@ -157,9 +159,10 @@ int lookup_hashtable(hash_table_t *table, hash_key_t key, hash_data_t *data)
 
 int addto_hashtable(hash_table_t *table, hash_key_t key, hash_data_t data)
 {
-   size_t newsize, index, startindex;
+   size_t newsize;
    int result;
    hash_hashvalue_t val;
+   hash_entry_t *entry;
 
    newsize = table->table_size;
    while (table->entry_count > newsize/2)
@@ -171,25 +174,18 @@ int addto_hashtable(hash_table_t *table, hash_key_t key, hash_data_t data)
    }
 
    val = table->hashfunc(key);
-   index = val % table->table_size;
-   startindex = index;
+   entry = insert(table, key, data, val);
+   if (!entry)
+      return -1;
 
-   for (;;) {
-      hash_entry_t *entry = table->table + index;
-      if (entry->status != INUSE) {
-         entry->key = key;
-         entry->data = data;
-         entry->hash_value = val;
-         entry->status = INUSE;
-         table->entry_count++;
-         return 0;
-      }
-      index++;
-      if (index == table->table_size)
-         index = 0;
-      if (index == startindex)
-         return -1;
-   }
+   entry->next = table->head;
+   entry->prev = NULL;
+   if (table->head)
+      table->head->prev = entry;
+   table->head = entry;
+   table->entry_count++;         
+   
+   return 0;
 }
 
 int removefrom_hashtable(hash_table_t *table, hash_key_t key)
@@ -205,8 +201,28 @@ int removefrom_hashtable(hash_table_t *table, hash_key_t key)
    entry->data = NULL;
    entry->hash_value = 0;
    entry->status = TOMBSTONE;
-
+   if (entry->next)
+      entry->next->prev = entry->prev;
+   if (entry->prev)
+      entry->prev->next = entry->next;
+   if (table->head == entry)
+      table->head = entry->next;
+   //Do not set entry->next to NULL, which would break the iterate & delete
+   //idiom used under dlopen_wrapper.
+   
    table->entry_count--;
+   return 0;
+}
+
+int foreach_hash_entry(hash_table_t *table, void *opaque, int (*cb)(hash_key_t key, hash_data_t data, void *opaque))
+{
+   int result;
+   struct hash_entry_t *i;
+   for (i = table->head; i != NULL; i = i->next) {
+      result = cb(i->key, i->data, opaque);
+      if (result != 0)
+         return result;
+   }
    return 0;
 }
 

--- a/src/hash.h
+++ b/src/hash.h
@@ -34,6 +34,7 @@ typedef struct
    hash_func_t hashfunc;
    hash_cmp_t keycmp;
    struct hash_entry_t *table;
+   struct hash_entry_t *head;
 } hash_table_t;
 
 int create_hashtable(hash_table_t *table, size_t initial_size, hash_func_t func, 
@@ -44,6 +45,7 @@ int destroy_hashtable(hash_table_t *table);
 int lookup_hashtable(hash_table_t *table, hash_key_t key, hash_data_t *data);
 int addto_hashtable(hash_table_t *table, hash_key_t key, hash_data_t data);
 int removefrom_hashtable(hash_table_t *table, hash_key_t key);
+int foreach_hash_entry(hash_table_t *table, void *opaque, int (*cb)(hash_key_t key, hash_data_t data, void *opaque));
 
 hash_hashvalue_t strhash(const char *str);
 

--- a/src/libc_wrappers.c
+++ b/src/libc_wrappers.c
@@ -573,6 +573,6 @@ char* gotcha_strncat(char* dest, const char* src, size_t n){
   dest = dest + gotcha_strlen(dest);
   size_t dest_stop = gotcha_strnlen(src, n);
   dest[dest_stop] = '\0';
-  memcpy(dest,src,n);
+  gotcha_memcpy(dest, (void *) src, n);
   return dest_begin;
 }

--- a/src/library_filters.c
+++ b/src/library_filters.c
@@ -14,7 +14,10 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 #include "library_filters.h"
 #include "libc_wrappers.h"
+
+static const char* filter;
 int (*libraryFilterFunc)(struct link_map*) = alwaysTrue;
+
 int alwaysTrue(struct link_map* candidate KNOWN_UNUSED){
   return 1;
 }

--- a/src/library_filters.h
+++ b/src/library_filters.h
@@ -23,7 +23,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 int alwaysTrue(struct link_map* candidate KNOWN_UNUSED);
 extern int (*libraryFilterFunc)(struct link_map*);
 
-static const char* filter;
 int trueIfNameMatches(struct link_map* target);
 int trueIfLast(struct link_map* target);
 void filterLibrariesByName(const char* nameFilter);

--- a/src/tool.c
+++ b/src/tool.c
@@ -108,8 +108,8 @@ binding_t *add_binding_to_tool(tool_t *tool, struct gotcha_binding_t *user_bindi
       internal_bindings[i].associated_binding_table = newbinding;
    }  
    //newbinding->user_binding = user_binding;
-   newbinding->user_binding = internal_bindings;
-   newbinding->user_binding_size = user_binding_size;
+   newbinding->internal_bindings = internal_bindings;
+   newbinding->internal_bindings_size = user_binding_size;
    result = create_hashtable(&newbinding->binding_hash, user_binding_size * 2, 
                              (hash_func_t) strhash, (hash_cmp_t) gotcha_strcmp);
    if (result != 0) {

--- a/src/tool.c
+++ b/src/tool.c
@@ -23,9 +23,11 @@ static binding_t *all_bindings = NULL;
 tool_t* get_tool_list(){
   return tools;
 }
+
 int tool_equal(tool_t* t1, tool_t* t2){
   return gotcha_strcmp(t1->tool_name,t2->tool_name);
 }
+
 void remove_tool_from_list(struct tool_t* target){
      const char* name = target->tool_name;
      if(!tools){
@@ -82,6 +84,7 @@ tool_t *create_tool(const char *tool_name)
    debug_printf(1, "Created new tool %s\n", tool_name);
    return newtool;
 }
+
 tool_t *get_tool(const char *tool_name)
 {
    tool_t *t;
@@ -209,6 +212,7 @@ struct gotcha_configuration_t get_default_configuration(){
   result.priority = UNSET_PRIORITY;
   return result;
 }
+
 enum gotcha_error_t get_default_configuration_value(enum gotcha_config_key_t key, void* data){
   struct gotcha_configuration_t config = get_default_configuration();
   if(key==GOTCHA_PRIORITY){
@@ -224,6 +228,7 @@ int gotcha_get_priority(const char* tool_name){
   get_configuration_value(tool_name, GOTCHA_PRIORITY,&return_value);
   return return_value;
 }
+
 enum gotcha_error_t get_configuration_value(const char* tool_name, enum gotcha_config_key_t key, void* location_to_store_result){
   struct tool_t* tool = get_tool(tool_name);
   if(tool==NULL){

--- a/src/tool.c
+++ b/src/tool.c
@@ -151,54 +151,6 @@ binding_t *get_tool_bindings(tool_t *tool)
    return tool->binding;
 }
 
-/**
- * TODO DO-NOT-MERGE "/" should be a macro of possible separators
- */
-struct gotcha_configuration_t get_configuration_for_tool(const char* tool_name_in){
-  printf("Creating config for tool %s\n",tool_name_in);
-  gotcha_init();
-  tool_t* possible_tool = get_tool(tool_name_in);
-  if(possible_tool){
-    printf("Returning config predefined\n");
-    return possible_tool->config;
-  }
-  else{ // TODO: do-not-merge, no hierarchy
-     possible_tool = create_tool(tool_name_in);
-     return possible_tool->config;
-  }
-  char tool_name[512];
-  strncpy(tool_name,tool_name_in,512);
-  char* string_iter;
-  string_iter = strtok((char*)tool_name, "/"); // TODO DO-NOT-MERGE gotcha_strtok
-  printf("strtok pointer %p value %s\n",(void*)string_iter,string_iter);
-  struct tool_t* tool_iter = get_tool(tool_name);
-  if(tool_iter == NULL){
-    tool_iter = create_tool(tool_name);
-  }
-  struct tool_t* lookup_key; 
-  char intermediate_name[512]; //TODO DO-NOT-MERGE implement, and is 512 enough?
-  strncpy(intermediate_name, string_iter, 512); //TODO DO-NOT-MERGE gotcha_strncpy
-  string_iter = strtok(NULL, "/"); // TODO DO-NOT-MERGE gotcha_strtok
-  while(string_iter!=NULL){
-    int lookup = lookup_hashtable(&tool_iter->child_tools, string_iter,(hash_data_t*) &lookup_key); 
-    strncat(intermediate_name, "/", 1); //TODO DO-NOT-MERGE gotcha_strncat
-    strncat(intermediate_name, string_iter, 512); //TODO DO-NOT-MERGE gotcha_strncat
-    if(lookup==-1){
-      char* new_tool_name = (char*)malloc(sizeof(char)*512); //TODO DO-NOT-MERGE implement, and is 512 enough?
-      struct tool_t* new_tool = create_tool(new_tool_name);
-      strncpy(new_tool_name,intermediate_name,512);
-      addto_hashtable(&tool_iter->child_tools, string_iter, new_tool);
-      new_tool->parent_tool = tool_iter;
-      tool_iter = new_tool;
-    }
-    else{
-      tool_iter = lookup_key;
-    }
-    string_iter = strtok(NULL, "/"); // TODO DO-NOT-MERGE gotcha_strtok
-  }
-  return tool_iter->config;
-}
-
 struct gotcha_configuration_t get_default_configuration(){
   struct gotcha_configuration_t result;
   result.priority = UNSET_PRIORITY;

--- a/src/tool.c
+++ b/src/tool.c
@@ -226,8 +226,8 @@ enum gotcha_error_t get_default_configuration_value(enum gotcha_config_key_t key
 enum gotcha_error_t get_configuration_value(const char* tool_name, enum gotcha_config_key_t key, void* location_to_store_result){
   struct tool_t* tool = get_tool(tool_name);
   if(tool==NULL){
-    debug_printf(1, "Property being examined for nonexistent tool %s\n", tool_name);
-    return GOTCHA_INVALID_CONFIGURATION;
+     error_printf("Property being examined for nonexistent tool %s\n", tool_name);
+     return GOTCHA_INVALID_TOOL;
   }
   get_default_configuration_value(key, location_to_store_result);
   int found_valid_value = 0;
@@ -242,8 +242,8 @@ enum gotcha_error_t get_configuration_value(const char* tool_name, enum gotcha_c
       }
     }
     else{
-      debug_printf(1, "Invalid property being configured on tool %s\n", tool_name);
-      return GOTCHA_INVALID_CONFIGURATION;
+      error_printf("Invalid property being configured on tool %s\n", tool_name);
+      return GOTCHA_INTERNAL;
     }
     tool = tool->parent_tool;
   }

--- a/src/tool.c
+++ b/src/tool.c
@@ -223,12 +223,6 @@ enum gotcha_error_t get_default_configuration_value(enum gotcha_config_key_t key
 
 }
 
-int gotcha_get_priority(const char* tool_name){
-  int return_value;
-  get_configuration_value(tool_name, GOTCHA_PRIORITY,&return_value);
-  return return_value;
-}
-
 enum gotcha_error_t get_configuration_value(const char* tool_name, enum gotcha_config_key_t key, void* location_to_store_result){
   struct tool_t* tool = get_tool(tool_name);
   if(tool==NULL){
@@ -254,4 +248,9 @@ enum gotcha_error_t get_configuration_value(const char* tool_name, enum gotcha_c
     tool = tool->parent_tool;
   }
   return GOTCHA_SUCCESS;  
+}
+
+int get_priority(tool_t *tool)
+{
+   return tool->config.priority;
 }

--- a/src/tool.h
+++ b/src/tool.h
@@ -40,8 +40,8 @@ struct gotcha_configuration_t {
  **/
 typedef struct binding_t {
    struct tool_t *tool;
-   struct internal_binding_t *user_binding;
-   int user_binding_size;
+   struct internal_binding_t *internal_bindings;
+   int internal_bindings_size;
    hash_table_t binding_hash;
    struct binding_t *next_tool_binding;
    struct binding_t *next_binding;

--- a/src/tool.h
+++ b/src/tool.h
@@ -36,6 +36,23 @@ struct gotcha_configuration_t {
 };
 
 /**
+ * A per-library structure
+ **/
+#define LIB_GOT_MARKED_WRITEABLE (1 << 0)
+#define LIB_PRESENT              (1 << 1)
+typedef struct library_t {
+   struct link_map *map;
+   struct library_t *next;
+   struct library_t *prev;
+   unsigned int generation;
+   int flags;
+} library_t;
+struct library_t *get_library(struct link_map *map);
+struct library_t *add_library(struct link_map *map);
+void remove_library(struct link_map *map);
+extern unsigned int current_generation;
+   
+/**
  * The internal structure that matches the external gotcha_binding_t.
  * In addition to the data specified in the gotcha_binding_t, we add:
  * - a linked-list pointer to the next binding table for this tool

--- a/src/tool.h
+++ b/src/tool.h
@@ -95,7 +95,7 @@ binding_t *get_tool_bindings(tool_t *tool);
 struct gotcha_configuration_t get_configuration_for_tool(const char* tool_name_in);
 struct gotcha_configuration_t get_default_configuration();
 enum gotcha_error_t get_configuration_value(const char* tool_name, enum gotcha_config_key_t key, void* location_to_store_result);
-int gotcha_get_priority(const char* tool_name);
+int get_priority(tool_t *tool);
 int tool_equal(tool_t* tool_1, tool_t* tool_2);
 
 #endif

--- a/src/tool.h
+++ b/src/tool.h
@@ -38,7 +38,6 @@ struct gotcha_configuration_t {
 /**
  * The internal structure that matches the external gotcha_binding_t.
  * In addition to the data specified in the gotcha_binding_t, we add:
- * - a hash table mapping function names to binding_ref_t
  * - a linked-list pointer to the next binding table for this tool
  * - a linked-list pointer to the next binding table
  **/
@@ -64,20 +63,9 @@ typedef struct tool_t {
    struct tool_t * parent_tool;
 } tool_t;
 
-/**
- * The target for hash tables that map from symbol names to 
- * binding_t entries.
- **/
-typedef struct binding_ref_t {
-   char *symbol_name;
-   binding_t *binding;
-   int index;
-} binding_ref_t;
-
 struct internal_binding_t {
   struct binding_t* associated_binding_table;
   struct gotcha_binding_t* user_binding;
-  int is_rewritten;
   struct internal_binding_t* next_binding;
 };
 

--- a/src/tool.h
+++ b/src/tool.h
@@ -24,6 +24,10 @@ struct tool_t;
 
 #define UNSET_PRIORITY (-1)
 
+enum gotcha_config_key_t {
+  GOTCHA_PRIORITY
+};
+
 /**
  * A structure representing how a given tool's bindings are configured
  */

--- a/src/tool.h
+++ b/src/tool.h
@@ -80,7 +80,6 @@ binding_t *add_binding_to_tool(tool_t *tool, struct gotcha_binding_t *user_bindi
 binding_t *get_bindings();
 binding_t *get_tool_bindings(tool_t *tool);
 
-struct gotcha_configuration_t get_configuration_for_tool(const char* tool_name_in);
 struct gotcha_configuration_t get_default_configuration();
 enum gotcha_error_t get_configuration_value(const char* tool_name, enum gotcha_config_key_t key, void* location_to_store_result);
 int get_priority(tool_t *tool);

--- a/test/unit/gotcha_unit_tests.c
+++ b/test/unit/gotcha_unit_tests.c
@@ -62,19 +62,6 @@ int check_pointer(void* ptr){
 extern int gotcha_prepare_symbols(binding_t *bindings, int num_names);
 
 int dummy_main(int argc, char* argv[]){return argv[argc-1][0];} //this is junk, will not be executed
-START_TEST(symbol_prep_test)
-{
-  int(*my_main)(int argc, char* argv[]) = 0;
-  struct gotcha_binding_t bindings[] = {
-    { "main", &dummy_main, &my_main  }
-  };
-  struct binding_t* internal_bindings = add_binding_to_tool(new_tool, bindings, 1);
-  ck_assert_msg(check_pointer(get_bindings()),"get_bindings shows no bindings");
-  ck_assert_msg(check_pointer(get_tool_bindings(new_tool)),"couldn't get bindings for created tool");
-  gotcha_prepare_symbols(internal_bindings,1);
-  ck_assert_msg((my_main!=0), "gotcha_prepare_symbols was not capable of finding function main");
-}
-END_TEST
 
 int(*orig_func)();
 int wrap_sample_func(){
@@ -113,7 +100,6 @@ Suite* gotcha_core_suite(){
   Suite* s = suite_create("Gotcha Core");
   TCase* core_case = configured_case_create("Wrapping");
   tcase_add_checked_fixture(core_case, setup_infrastructure, teardown_infrastructure);
-  tcase_add_test(core_case, symbol_prep_test);
   tcase_add_test(core_case, symbol_wrap_test);
   tcase_add_test(core_case, bad_lookup_test);
   tcase_add_test(core_case, auto_tool_creation);
@@ -124,13 +110,6 @@ Suite* gotcha_core_suite(){
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////Libc Wrapper Tests//////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-// TODO: this test has no way to fail except segfaults. Need to ensure it does sane things
-START_TEST(debug_print_test){
-  struct link_map* print_me = _r_debug.r_map;
-  debug_print(print_me,"");
-}
-END_TEST
 
 START_TEST(gotcha_malloc_test){
   int* x = (int*)gotcha_malloc(sizeof(int)*10);
@@ -347,7 +326,6 @@ END_TEST
 Suite* gotcha_libc_suite(){
   Suite* s = suite_create("Gotcha Libc");
   TCase* libc_case = configured_case_create("Basic tests");
-  tcase_add_test(libc_case, debug_print_test);
   tcase_add_test(libc_case, gotcha_malloc_test);
   tcase_add_test(libc_case, gotcha_free_test);
   tcase_add_test(libc_case, gotcha_realloc_test);


### PR DESCRIPTION
Restructured the code that handles ordering and binding for multiple tools.  The rewrite_wrapper_orders function now takes a first pass over the set of tools and calculates the minimum needed GOT rewrites and symbol lookups to incorporate the new tool (we used to reapply all GOT rewrites on a new tool addition).

We also now have a library_t object to track when libraries are added and removed, which was useful for making libraries that are dlopened only apply a minimal change.

Also did general clean-up, more debugging prints, and numerous smaller bug fixes.  Needs more testing before merge.