### PR TITLE
Indirection now thrown in

### DIFF
--- a/include/gotcha/gotcha.h
+++ b/include/gotcha/gotcha.h
@@ -122,11 +122,4 @@ GOTCHA_EXPORT void* gotcha_get_wrappee(gotcha_wrappee_handle_t handle);
 }
 #endif
 
-#if defined(__cplusplus)
-template<typename T,typename DataPointerType>
-T* castFunctionPointer(DataPointerType in){
-  return reinterpret_cast<T*>(in);
-}
-#endif
-
 #endif

--- a/include/gotcha/gotcha.h
+++ b/include/gotcha/gotcha.h
@@ -105,9 +105,28 @@ GOTCHA_EXPORT enum gotcha_error_t gotcha_set_priority(const char* tool_name, int
  */
 GOTCHA_EXPORT enum gotcha_error_t gotcha_get_priority(const char* tool_name, int *priority);
 
+/*!
+ ******************************************************************************
+ *
+ * \fn enum void* gotcha_get_wrappee(gotcha_wrappee_handle_t)
+ *
+ * \brief Given a GOTCHA wrapper's handle, returns the wrapped function for it to call
+ *
+ * \param handle The wrappee handle to return the function pointer for
+ *
+ ******************************************************************************
+ */
+GOTCHA_EXPORT void* gotcha_get_wrappee(gotcha_wrappee_handle_t handle);
+
 #if defined(__cplusplus) 
 }
 #endif
 
+#if defined(__cplusplus)
+template<typename T,typename DataPointerType>
+T* castFunctionPointer(DataPointerType in){
+  return reinterpret_cast<T*>(in);
+}
+#endif
 
 #endif

--- a/include/gotcha/gotcha_types.h
+++ b/include/gotcha/gotcha_types.h
@@ -28,15 +28,17 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 extern "C" {
 #endif
 
+typedef void* gotcha_wrappee_handle_t;
+
 /*!
  * The representation of a Gotcha action
  * as it passes through the pipeline
  */
 struct gotcha_binding_t {
-  const char* name;                //!< The name of the function being wrapped
-  void* wrapper_pointer;           //!< A pointer to the wrapper function
-  void* function_address_pointer;  //!< A pointer to the function being wrapped
-  void* opaque_handle;             //!< This pointer is for Gotcha developer use only
+  const char* name;                                //!< The name of the function being wrapped
+  void* wrapper_pointer;                           //!< A pointer to the wrapper function
+  gotcha_wrappee_handle_t function_address_pointer;  //!< A pointer to the function being wrapped
+  void* opaque_handle;                             //!< This pointer is for Gotcha developer use only
 };
 
 /*!
@@ -51,6 +53,13 @@ enum gotcha_error_t {
 
 #if defined(__cplusplus) 
 }
+#endif
+
+#if defined(__cplusplus)
+//template<typename T>
+//T* castFunctionPointer(void* in){
+//  return reinterpret_cast<T*>(in);
+//}
 #endif
 
 #endif

--- a/include/gotcha/gotcha_types.h
+++ b/include/gotcha/gotcha_types.h
@@ -37,7 +37,7 @@ typedef void* gotcha_wrappee_handle_t;
 struct gotcha_binding_t {
   const char* name;                                //!< The name of the function being wrapped
   void* wrapper_pointer;                           //!< A pointer to the wrapper function
-  gotcha_wrappee_handle_t function_address_pointer;  //!< A pointer to the function being wrapped
+  gotcha_wrappee_handle_t function_handle;         //!< A pointer to the function being wrapped
   void* opaque_handle;                             //!< This pointer is for Gotcha developer use only
 };
 
@@ -53,13 +53,6 @@ enum gotcha_error_t {
 
 #if defined(__cplusplus) 
 }
-#endif
-
-#if defined(__cplusplus)
-//template<typename T>
-//T* castFunctionPointer(void* in){
-//  return reinterpret_cast<T*>(in);
-//}
 #endif
 
 #endif

--- a/src/gotcha.c
+++ b/src/gotcha.c
@@ -113,7 +113,8 @@ static void insert_at_head(struct internal_binding_t *binding, struct internal_b
 {
    binding->next_binding = head;
    /** OPAQUE */
-   (*(void**)binding->user_binding->function_handle) = head->user_binding->wrapper_pointer;
+   setInternalBindingAddressPointer(binding->user_binding->function_handle, head->user_binding->wrapper_pointer);
+   //(*(void**)binding->user_binding->function_handle) = head->user_binding->wrapper_pointer;
    /** END OPAQUE */
    removefrom_hashtable(&function_hash_table, (void*) binding->user_binding->name);
    addto_hashtable(&function_hash_table, (void*)binding->user_binding->name, (void*)binding);
@@ -288,7 +289,7 @@ GOTCHA_EXPORT enum gotcha_error_t gotcha_wrap(struct gotcha_binding_t* user_bind
   for (i = 0; i < num_actions; i++) {
     /** OPAQUE */
     //user_bindings[i].function_handle
-    //setBindingAddressPointer(&user_bindings[i], NULL);
+    setBindingAddressPointer(&user_bindings[i], NULL);
     /** END OPAQUE */
   }
 

--- a/src/gotcha.c
+++ b/src/gotcha.c
@@ -37,11 +37,14 @@ static void setBindingAddressPointer(struct gotcha_binding_t* in, void* value){
 }
 
 static void** getInternalBindingAddressPointer(struct internal_binding_t** in){
+  debug_printf(4,"Innermost1: %p\n",*in);
   return (void**)&((*in)->wrappee_pointer);
 }
 
 static void setInternalBindingAddressPointer(struct internal_binding_t** in, void* value){
+  debug_printf(4, "Attempting to write a value of %p to %p\n",value, in);
   void** target = getInternalBindingAddressPointer(in);
+  debug_printf(3, "Updating binding address pointer at %p to %p\n", target, value);
   writeAddress(target, value);
 }
 
@@ -122,17 +125,22 @@ static void insert_at_head(struct internal_binding_t *binding, struct internal_b
 
 static void insert_after_pos(struct internal_binding_t *binding, struct internal_binding_t *pos)
 {
+   debug_printf(4, "1\n");
    /** OPAQUE */
    //setBindingAddressPointer(binding->user_binding, *((void **) pos->user_binding->function_handle));
    setInternalBindingAddressPointer(binding->user_binding->function_handle, /***((void **)*/ pos->wrappee_pointer);
+   debug_printf(4, "2 %p %p %p %p %p %p\n", pos, pos->user_binding, pos->user_binding->function_handle, binding, binding->user_binding, binding->user_binding->wrapper_pointer);
    //((struct internal_binding_t*)(binding->user_binding->function_handle))->wrappee_pointer = pos->wrappee_pointer;
    setInternalBindingAddressPointer(pos->user_binding->function_handle, binding->user_binding->wrapper_pointer);
+   debug_printf(4, "3\n");
    //((struct internal_binding_t*)(pos->user_binding->function_handle))->wrappee_pointer = binding->user_binding->wrapper_pointer;
    //setInternalBindingAddressPointer(pos, binding->user_binding->wrapper_pointer);
    //setInternalBindingAddressPointer(pos->user_binding->function_handle, binding->user_binding->wrapper_pointer);
    /** END OPAQUE */
    binding->next_binding = pos->next_binding;
+   debug_printf(4, "5\n");
    pos->next_binding = binding;
+   debug_printf(4, "6\n");
 }
 
 #define RWO_NOCHANGE 0

--- a/src/gotcha.c
+++ b/src/gotcha.c
@@ -27,7 +27,7 @@ static void writeAddress(void* write, void* value){
 }
 
 static void** getBindingAddressPointer(struct gotcha_binding_t* in){
-  return (void**)in->function_address_pointer;
+  return (void**)in->function_handle;
 }
 
 static void setBindingAddressPointer(struct gotcha_binding_t* in, void* value){
@@ -99,14 +99,14 @@ int prepare_symbol(struct internal_binding_t *binding)
 static void insert_at_head(struct internal_binding_t *binding, struct internal_binding_t *head)
 {
    binding->next_binding = head;
-   (*(void**)binding->user_binding->function_address_pointer) = head->user_binding->wrapper_pointer;
+   (*(void**)binding->user_binding->function_handle) = head->user_binding->wrapper_pointer;
    removefrom_hashtable(&function_hash_table, (void*) binding->user_binding->name);
    addto_hashtable(&function_hash_table, (void*)binding->user_binding->name, (void*)binding);
 }
 
 static void insert_after_pos(struct internal_binding_t *binding, struct internal_binding_t *pos)
 {
-   setBindingAddressPointer(binding->user_binding, *((void **) pos->user_binding->function_address_pointer));
+   setBindingAddressPointer(binding->user_binding, *((void **) pos->user_binding->function_handle));
    setBindingAddressPointer(pos->user_binding, binding->user_binding->wrapper_pointer);
    binding->next_binding = pos->next_binding;
    pos->next_binding = binding;
@@ -293,7 +293,7 @@ GOTCHA_EXPORT enum gotcha_error_t gotcha_wrap(struct gotcha_binding_t* user_bind
      int result = rewrite_wrapper_orders(binding);
      if (result & RWO_NEED_LOOKUP) {
         debug_printf(2, "Symbol %s needs lookup operation\n", binding->user_binding->name);
-        gotcha_assert(*((void **) binding->user_binding->function_address_pointer) == NULL);
+        gotcha_assert(*((void **) binding->user_binding->function_handle) == NULL);
         int presult = prepare_symbol(binding);
         if (presult == -1) {
            debug_printf(2, "Stashing %s in notfound_binding table to re-lookup on dlopens\n",

--- a/src/gotcha.c
+++ b/src/gotcha.c
@@ -117,7 +117,7 @@ static void insert_at_head(struct internal_binding_t *binding, struct internal_b
 
 static void insert_after_pos(struct internal_binding_t *binding, struct internal_binding_t *pos)
 {
-   setInternalBindingAddressPointer(binding->user_binding->function_handle, /***((void **)*/ pos->wrappee_pointer);
+   setInternalBindingAddressPointer(binding->user_binding->function_handle, pos->wrappee_pointer);
    setInternalBindingAddressPointer(pos->user_binding->function_handle, binding->user_binding->wrapper_pointer);
    binding->next_binding = pos->next_binding;
    pos->next_binding = binding;

--- a/src/gotcha.c
+++ b/src/gotcha.c
@@ -361,3 +361,6 @@ GOTCHA_EXPORT enum gotcha_error_t gotcha_get_priority(const char* tool_name, int
   return get_configuration_value(tool_name, GOTCHA_PRIORITY, priority);
 }
 
+GOTCHA_EXPORT void* gotcha_get_wrappee(gotcha_wrappee_handle_t handle){
+  return handle;
+}

--- a/src/gotcha_dl.c
+++ b/src/gotcha_dl.c
@@ -7,8 +7,8 @@
 
 void* _dl_sym(void* handle, const char* name, void* where);
 
-static gotcha_wrappee_handle_t orig_dlopen_handle;
-static gotcha_wrappee_handle_t orig_dlsym_handle;
+gotcha_wrappee_handle_t orig_dlopen_handle;
+gotcha_wrappee_handle_t orig_dlsym_handle;
 
 static int per_binding(hash_key_t key, hash_data_t data, void *opaque KNOWN_UNUSED)
 {
@@ -65,11 +65,11 @@ static void* dlsym_wrapper(void* handle, const char* symbol_name){
      return binding->user_binding->wrapper_pointer;
 }
 
+struct gotcha_binding_t dl_binds[] = {
+  {"dlopen", dlopen_wrapper, &orig_dlopen_handle},
+  {"dlsym", dlsym_wrapper, &orig_dlsym_handle}
+};     
 void handle_libdl(){
-  struct gotcha_binding_t dl_binds[] = {
-    {"dlopen", dlopen_wrapper, &orig_dlopen_handle},
-    {"dlsym", dlsym_wrapper, &orig_dlsym_handle}
-  };     
   gotcha_wrap(dl_binds, 2, "gotcha");
 }
 

--- a/src/gotcha_dl.h
+++ b/src/gotcha_dl.h
@@ -8,4 +8,8 @@ void handle_libdl();
 extern void update_all_library_gots(hash_table_t *bindings);
 extern int prepare_symbol(struct internal_binding_t *binding);
 
+extern gotcha_wrappee_handle_t orig_dlopen_handle;
+extern gotcha_wrappee_handle_t orig_dlsym_handle;
+
+extern struct gotcha_binding_t dl_binds[];
 #endif

--- a/src/tool.h
+++ b/src/tool.h
@@ -84,6 +84,9 @@ struct internal_binding_t {
   struct binding_t* associated_binding_table;
   struct gotcha_binding_t* user_binding;
   struct internal_binding_t* next_binding;
+  /** OPAQUE */
+  void* wrappee_pointer;
+  /** END OPAQUE */
 };
 
 tool_t *create_tool(const char *tool_name);

--- a/src/tool.h
+++ b/src/tool.h
@@ -84,9 +84,7 @@ struct internal_binding_t {
   struct binding_t* associated_binding_table;
   struct gotcha_binding_t* user_binding;
   struct internal_binding_t* next_binding;
-  /** OPAQUE */
   void* wrappee_pointer;
-  /** END OPAQUE */
 };
 
 tool_t *create_tool(const char *tool_name);

--- a/test/dlopen/test_dlopen.c
+++ b/test/dlopen/test_dlopen.c
@@ -41,8 +41,6 @@ int correct_return_five()
    return 5;
 }
 
-//static int (*buggy_return_four)(void);
-//static int (*buggy_return_five)(void);
 
 static gotcha_wrappee_handle_t buggy_return_four;
 static gotcha_wrappee_handle_t buggy_return_five;

--- a/test/dlopen/test_dlopen.c
+++ b/test/dlopen/test_dlopen.c
@@ -41,9 +41,11 @@ int correct_return_five()
    return 5;
 }
 
-static int (*buggy_return_four)(void);
-static int (*buggy_return_five)(void);
+//static int (*buggy_return_four)(void);
+//static int (*buggy_return_five)(void);
 
+static gotcha_wrappee_handle_t buggy_return_four;
+static gotcha_wrappee_handle_t buggy_return_five;
 struct gotcha_binding_t funcs[] = {
    { "return_four", correct_return_four, &buggy_return_four },
    { "return_five", correct_return_five, &buggy_return_five }

--- a/test/hammer/gen.cc
+++ b/test/hammer/gen.cc
@@ -61,11 +61,9 @@ public:
 
 template<int A, int B>
 gotcha_wrappee_handle_t Neg<A, B>::mathfn_mult_handle= NULL;
-//result_t (*Neg<A, B>::mathfn_mult)(void) = NULL;
 
 template<int A, int B>
 gotcha_wrappee_handle_t Neg<A, B>::mathfn_add_handle= NULL;
-//result_t (*Neg<A, B>::mathfn_add)(void) = NULL;
 
 void initMath()
 {

--- a/test/hammer/gen.cc
+++ b/test/hammer/gen.cc
@@ -60,10 +60,12 @@ public:
 };
 
 template<int A, int B>
-result_t (*Neg<A, B>::mathfn_mult)(void) = NULL;
+gotcha_wrappee_handle_t Neg<A, B>::mathfn_mult_handle= NULL;
+//result_t (*Neg<A, B>::mathfn_mult)(void) = NULL;
 
 template<int A, int B>
-result_t (*Neg<A, B>::mathfn_add)(void) = NULL;
+gotcha_wrappee_handle_t Neg<A, B>::mathfn_add_handle= NULL;
+//result_t (*Neg<A, B>::mathfn_add)(void) = NULL;
 
 void initMath()
 {

--- a/test/hammer/math.hpp
+++ b/test/hammer/math.hpp
@@ -20,7 +20,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 #include <utility>
 #include <string>
 #include <set>
-
+#include <gotcha/gotcha.h>
 #include "wrap.h"
 
 #define X XSIZE
@@ -56,19 +56,20 @@ public:
 template <int A, int B>
 class Neg {
 public:
-   static result_t (*mathfn_mult)(void);
-   static result_t (*mathfn_add)(void);
-
+   static gotcha_wrappee_handle_t mathfn_add_handle;
+   static gotcha_wrappee_handle_t mathfn_mult_handle;
    static void init() {
-      multinfo.addNegPtr(A, B, (void *) Neg<A, B>::mult_math_wrapper, (void *) &mathfn_mult);
-      addinfo.addNegPtr(A, B, (void *) Neg<A, B>::add_math_wrapper, (void *) &mathfn_add);
+      multinfo.addNegPtr(A, B, (void *) Neg<A, B>::mult_math_wrapper, (void *) &mathfn_mult_handle);
+      addinfo.addNegPtr(A, B, (void *) Neg<A, B>::add_math_wrapper, (void *) &mathfn_add_handle);
    }
 
    static result_t mult_math_wrapper() {
+      auto mathfn_mult = castFunctionPointer<decltype(mult_math_wrapper)>(mathfn_mult_handle); 
       return mathfn_mult() * -1;
    }
 
    static result_t add_math_wrapper() {
+      auto mathfn_add = castFunctionPointer<decltype(add_math_wrapper)>(mathfn_add_handle); 
       return mathfn_add() * -1;
    }
 };

--- a/test/hammer/math.hpp
+++ b/test/hammer/math.hpp
@@ -64,12 +64,12 @@ public:
    }
 
    static result_t mult_math_wrapper() {
-      auto mathfn_mult = reinterpret_cast<decltype(&mult_math_wrapper)>(mathfn_mult_handle);
+      auto mathfn_mult = reinterpret_cast<decltype(&mult_math_wrapper)>(gotcha_get_wrappee(mathfn_mult_handle));
       return mathfn_mult() * -1;
    }
 
    static result_t add_math_wrapper() {
-      auto mathfn_add = reinterpret_cast<decltype(&add_math_wrapper)>(mathfn_add_handle);
+      auto mathfn_add = reinterpret_cast<decltype(&add_math_wrapper)>(gotcha_get_wrappee(mathfn_add_handle));
       return mathfn_add() * -1;
    }
 };

--- a/test/hammer/math.hpp
+++ b/test/hammer/math.hpp
@@ -64,12 +64,12 @@ public:
    }
 
    static result_t mult_math_wrapper() {
-      auto mathfn_mult = castFunctionPointer<decltype(mult_math_wrapper)>(mathfn_mult_handle); 
+      auto mathfn_mult = reinterpret_cast<decltype(&mult_math_wrapper)>(mathfn_mult_handle);
       return mathfn_mult() * -1;
    }
 
    static result_t add_math_wrapper() {
-      auto mathfn_add = castFunctionPointer<decltype(add_math_wrapper)>(mathfn_add_handle); 
+      auto mathfn_add = reinterpret_cast<decltype(&add_math_wrapper)>(mathfn_add_handle);
       return mathfn_add() * -1;
    }
 };

--- a/test/hammer/wrap.cc
+++ b/test/hammer/wrap.cc
@@ -69,7 +69,7 @@ bool WrapperInfo::dowrap(std::string toolname)
 
       bindings[j].name = i->second.c_str();
       bindings[j].wrapper_pointer = neg->second.first;
-      bindings[j].function_address_pointer = neg->second.second;
+      bindings[j].function_handle = neg->second.second;
    }
 
    auto start = chrono::steady_clock::now();

--- a/test/multi_agent_dlopen/main.c
+++ b/test/multi_agent_dlopen/main.c
@@ -15,9 +15,6 @@ typedef double sin_fcn_t(double);
 int
 main(int argc, char **argv)
 {
-    void* mon_hand = dlopen("libmon.so",RTLD_NOW);
-    void (*init)() = dlsym(mon_hand, "fix_things");
-    init();
     sin_fcn_t *sin_fcn = NULL;
     double val = 4.0;
     double ans = 0.0;

--- a/test/multi_agent_dlopen/main.c
+++ b/test/multi_agent_dlopen/main.c
@@ -15,6 +15,9 @@ typedef double sin_fcn_t(double);
 int
 main(int argc, char **argv)
 {
+    void* mon_hand = dlopen("libmon.so",RTLD_NOW);
+    void (*init)() = dlsym(mon_hand, "fix_things");
+    init();
     sin_fcn_t *sin_fcn = NULL;
     double val = 4.0;
     double ans = 0.0;

--- a/test/multi_agent_dlopen/monitor.c
+++ b/test/multi_agent_dlopen/monitor.c
@@ -16,11 +16,12 @@
 
 typedef void *dlopen_fcn_t(const char *, int);
 
-void*(*reel_dlopen)(const char*, int);
+gotcha_wrappee_handle_t reel_dlopen_handle;
 
 void *
 wrap_dlopen(const char *file, int flag)
 {
+    typeof(&wrap_dlopen) reel_dlopen = gotcha_get_wrappee(reel_dlopen_handle);
     fprintf(stderr, "ENTER WRAP: %p\n", reel_dlopen);
     fprintf(stderr, "%s:  enter dlopen:  file = %s\n", MYNAME, file);
 
@@ -34,11 +35,12 @@ wrap_dlopen(const char *file, int flag)
 }
 
 struct gotcha_binding_t binds[] = {
-  { "dlopen", wrap_dlopen, &reel_dlopen}
+  { "dlopen", wrap_dlopen, &reel_dlopen_handle}
 };
 __attribute__((constructor)) void fix_things(){
-  reel_dlopen = NULL;
+  reel_dlopen_handle = NULL;
   gotcha_wrap(binds, 1, "silly");
+  typeof(&wrap_dlopen) reel_dlopen = gotcha_get_wrappee(reel_dlopen_handle);
   fprintf(stderr, "IMMEDIATE WRITE: %p\n", reel_dlopen);
   
 }

--- a/test/multi_agent_dlopen/monitor.c
+++ b/test/multi_agent_dlopen/monitor.c
@@ -33,13 +33,13 @@ wrap_dlopen(const char *file, int flag)
 
     return ans;
 }
-
+void* opaque;
 struct gotcha_binding_t binds[] = {
   { "dlopen", wrap_dlopen, &reel_dlopen_handle}
 };
 __attribute__((constructor)) void fix_things(){
-  //reel_dlopen_handle = NULL;
-  printf("OOPS\n");
+  reel_dlopen_handle = NULL;
+  printf("OOPS %p\n", &reel_dlopen_handle);
   gotcha_wrap(binds, 1, "silly");
   printf("OOPS\n");
   typeof(&wrap_dlopen) reel_dlopen = gotcha_get_wrappee(reel_dlopen_handle);

--- a/test/multi_agent_dlopen/monitor.c
+++ b/test/multi_agent_dlopen/monitor.c
@@ -38,8 +38,10 @@ struct gotcha_binding_t binds[] = {
   { "dlopen", wrap_dlopen, &reel_dlopen_handle}
 };
 __attribute__((constructor)) void fix_things(){
-  reel_dlopen_handle = NULL;
+  //reel_dlopen_handle = NULL;
+  printf("OOPS\n");
   gotcha_wrap(binds, 1, "silly");
+  printf("OOPS\n");
   typeof(&wrap_dlopen) reel_dlopen = gotcha_get_wrappee(reel_dlopen_handle);
   fprintf(stderr, "IMMEDIATE WRITE: %p\n", reel_dlopen);
   

--- a/test/multi_agent_dlopen/monitor.c
+++ b/test/multi_agent_dlopen/monitor.c
@@ -37,12 +37,14 @@ void* opaque;
 struct gotcha_binding_t binds[] = {
   { "dlopen", wrap_dlopen, &reel_dlopen_handle}
 };
-__attribute__((constructor)) void fix_things(){
+void fix_things(){
   reel_dlopen_handle = NULL;
   printf("OOPS %p\n", &reel_dlopen_handle);
   gotcha_wrap(binds, 1, "silly");
   printf("OOPS\n");
   typeof(&wrap_dlopen) reel_dlopen = gotcha_get_wrappee(reel_dlopen_handle);
   fprintf(stderr, "IMMEDIATE WRITE: %p\n", reel_dlopen);
-  
+}
+__attribute__((constructor)) void startup_fix_things(){
+  //fix_things(); 
 }

--- a/test/multi_agent_dlopen/monitor.c
+++ b/test/multi_agent_dlopen/monitor.c
@@ -39,9 +39,7 @@ struct gotcha_binding_t binds[] = {
 };
 void fix_things(){
   reel_dlopen_handle = NULL;
-  printf("OOPS %p\n", &reel_dlopen_handle);
   gotcha_wrap(binds, 1, "silly");
-  printf("OOPS\n");
   typeof(&wrap_dlopen) reel_dlopen = gotcha_get_wrappee(reel_dlopen_handle);
   fprintf(stderr, "IMMEDIATE WRITE: %p\n", reel_dlopen);
 }

--- a/test/multi_agent_dlopen/monitor.c
+++ b/test/multi_agent_dlopen/monitor.c
@@ -46,5 +46,5 @@ void fix_things(){
   fprintf(stderr, "IMMEDIATE WRITE: %p\n", reel_dlopen);
 }
 __attribute__((constructor)) void startup_fix_things(){
-  //fix_things(); 
+  fix_things(); 
 }

--- a/test/ppc_stress_multi_module/tool1.c
+++ b/test/ppc_stress_multi_module/tool1.c
@@ -26,14 +26,15 @@ int storage2test = 5;
 
 static int retX_wrapper(int x);
 
-static int(*origRetX)(int) = 0x0;
+static gotcha_wrappee_handle_t origRetX_handle = 0x0;
 
 #define NUM_IOFUNCS 1
 struct gotcha_binding_t iofuncs[] = {
-   { "retX",retX_wrapper,&origRetX}
+   { "retX",retX_wrapper,&origRetX_handle}
 };
 
 int retX_wrapper(int x){
+  typeof(&retX_wrapper) origRetX = gotcha_get_wrappee(origRetX_handle);
   printf("In tool1 wrapper, calling %p\n", origRetX);
   return origRetX ? (origRetX(x) + storage1test + storage2test ) : 0;
 }

--- a/test/priority/tool1.c
+++ b/test/priority/tool1.c
@@ -23,14 +23,15 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
 static char* retX_wrapper(char* x);
 
-static char*(*origRetX)(char*) = 0x0;
+static gotcha_wrappee_handle_t origRetX_handle = 0x0;
 
 #define NUM_IOFUNCS 1
 struct gotcha_binding_t iofuncs[] = {
-   { "retX",retX_wrapper,&origRetX}
+   { "retX",retX_wrapper,&origRetX_handle}
 };
 
 char* retX_wrapper(char* x){
+  typeof(&retX_wrapper) origRetX = gotcha_get_wrappee(origRetX_handle);
   strcat(x,"t1=>");
  
   return origRetX ? (origRetX(x) ) : 0;

--- a/test/priority/tool2.c
+++ b/test/priority/tool2.c
@@ -23,14 +23,15 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
 __attribute__((unused)) static char* retX_wrapper(char* x);
 
-static char*(*origRetX)(char*) = 0x0;
+static gotcha_wrappee_handle_t origRetX_handle = 0x0;
 
 #define NUM_IOFUNCS 1
 struct gotcha_binding_t iofuncs2[] = {
-   { "retX",retX_wrapper,&origRetX}
+   { "retX",retX_wrapper,&origRetX_handle}
 };
 
 char* retX_wrapper(char* x){
+  typeof(&retX_wrapper) origRetX = gotcha_get_wrappee(origRetX_handle);
   strcat(x,"t2=>");
  
   return origRetX ? (origRetX(x) ) : 0;

--- a/test/priority/tool3.c
+++ b/test/priority/tool3.c
@@ -23,14 +23,15 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
 __attribute__((unused)) static char* retX_wrapper(char* x);
 
-static char*(*origRetX)(char*) = 0x0;
+static gotcha_wrappee_handle_t origRetX_handle = 0x0;
 
 #define NUM_IOFUNCS 1
 struct gotcha_binding_t iofuncs3[] = {
-   { "retX",retX_wrapper,&origRetX}
+   { "retX",retX_wrapper,&origRetX_handle}
 };
 
 char* retX_wrapper(char* x){
+  typeof(&retX_wrapper) origRetX = gotcha_get_wrappee(origRetX_handle);
   strcat(x,"t3=>");
  
   return origRetX ? (origRetX(x)) : 0;

--- a/test/rogot/autotee.c
+++ b/test/rogot/autotee.c
@@ -37,15 +37,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 static int tee_fd = -1;
 static FILE *tee_FILE = NULL;
 
-//static int (*orig_printf)(const char *, ...);
-//static int (*orig_fprintf)(FILE *, const char *, ...);
-//static int (*orig_vfprintf)(FILE *, const char *, va_list);
-//static int (*orig_vprintf)(const char *, va_list);
-//static ssize_t (*orig_write)(int, const void *, size_t);
-//static int (*orig_puts)(const char *);
-//static int (*orig_fputs)(const char *, FILE *);
-//static int (*orig_fwrite)(const void *, size_t, size_t, FILE *);
-//
 static int printf_wrapper(const char *format, ...);
 static int fprintf_wrapper(FILE *stream, const char *format, ...);
 static int vfprintf_wrapper(FILE *stream, const char *str, va_list args);

--- a/test/rogot/autotee.c
+++ b/test/rogot/autotee.c
@@ -37,15 +37,15 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 static int tee_fd = -1;
 static FILE *tee_FILE = NULL;
 
-static int (*orig_printf)(const char *, ...);
-static int (*orig_fprintf)(FILE *, const char *, ...);
-static int (*orig_vfprintf)(FILE *, const char *, va_list);
-static int (*orig_vprintf)(const char *, va_list);
-static ssize_t (*orig_write)(int, const void *, size_t);
-static int (*orig_puts)(const char *);
-static int (*orig_fputs)(const char *, FILE *);
-static int (*orig_fwrite)(const void *, size_t, size_t, FILE *);
-
+//static int (*orig_printf)(const char *, ...);
+//static int (*orig_fprintf)(FILE *, const char *, ...);
+//static int (*orig_vfprintf)(FILE *, const char *, va_list);
+//static int (*orig_vprintf)(const char *, va_list);
+//static ssize_t (*orig_write)(int, const void *, size_t);
+//static int (*orig_puts)(const char *);
+//static int (*orig_fputs)(const char *, FILE *);
+//static int (*orig_fwrite)(const void *, size_t, size_t, FILE *);
+//
 static int printf_wrapper(const char *format, ...);
 static int fprintf_wrapper(FILE *stream, const char *format, ...);
 static int vfprintf_wrapper(FILE *stream, const char *str, va_list args);
@@ -55,16 +55,26 @@ static int puts_wrapper(const char *str);
 static int fputs_wrapper(const char *str, FILE *f);
 static int fwrite_wrapper(const void *ptr, size_t size, size_t nmemb, FILE *stream);
 
+static gotcha_wrappee_handle_t orig_printf_handle;
+static gotcha_wrappee_handle_t orig_fprintf_handle;
+static gotcha_wrappee_handle_t orig_vfprintf_handle;
+static gotcha_wrappee_handle_t orig_vprintf_handle;
+static gotcha_wrappee_handle_t orig_write_handle;
+static gotcha_wrappee_handle_t orig_puts_handle;
+static gotcha_wrappee_handle_t orig_fputs_handle;
+static gotcha_wrappee_handle_t orig_fwrite_handle;
+
+
 #define NUM_IOFUNCS 8
 struct gotcha_binding_t iofuncs[] = {
-   { "printf", printf_wrapper, &orig_printf },
-   { "fprintf", fprintf_wrapper, &orig_fprintf },
-   { "vfprintf", vfprintf_wrapper, &orig_vfprintf },
-   { "vprintf", vprintf_wrapper, &orig_vprintf },
-   { "write", write_wrapper, &orig_write },
-   { "puts", puts_wrapper, &orig_puts },
-   { "fputs", fputs_wrapper, &orig_fputs },
-   { "fwrite", fwrite_wrapper, &orig_fwrite }
+   { "printf", printf_wrapper, &orig_printf_handle },
+   { "fprintf", fprintf_wrapper, &orig_fprintf_handle },
+   { "vfprintf", vfprintf_wrapper, &orig_vfprintf_handle },
+   { "vprintf", vprintf_wrapper, &orig_vprintf_handle },
+   { "write", write_wrapper, &orig_write_handle },
+   { "puts", puts_wrapper, &orig_puts_handle },
+   { "fputs", fputs_wrapper, &orig_fputs_handle },
+   { "fwrite", fwrite_wrapper, &orig_fwrite_handle }
 };
 
 int init_autotee(const char *teefile)
@@ -98,6 +108,8 @@ int close_autotee()
 
 static int printf_wrapper(const char *format, ...)
 {
+   typeof(&vfprintf) orig_vfprintf = gotcha_get_wrappee(orig_vfprintf_handle);
+   typeof(&vprintf) orig_vprintf = gotcha_get_wrappee(orig_vprintf_handle);
    int result;
    va_list args, args2;
    va_start(args, format);
@@ -116,6 +128,7 @@ static int printf_wrapper(const char *format, ...)
 
 static int fprintf_wrapper(FILE *stream, const char *format, ...)
 {
+   typeof(&vfprintf) orig_vfprintf = gotcha_get_wrappee(orig_vfprintf_handle);
    int result;
    va_list args, args2;
    va_start(args, format);
@@ -138,6 +151,7 @@ static int fprintf_wrapper(FILE *stream, const char *format, ...)
 
 static int vfprintf_wrapper(FILE *stream, const char *str, va_list args)
 {
+   typeof(&vfprintf) orig_vfprintf = gotcha_get_wrappee(orig_vfprintf_handle);
    va_list args2;
    if (stream != stdout) {
       return orig_vfprintf(stream, str, args);
@@ -152,6 +166,8 @@ static int vfprintf_wrapper(FILE *stream, const char *str, va_list args)
 
 static int vprintf_wrapper(const char *str, va_list args)
 {
+   typeof(&vfprintf) orig_vfprintf = gotcha_get_wrappee(orig_vfprintf_handle);
+   typeof(&vprintf) orig_vprintf = gotcha_get_wrappee(orig_vprintf_handle);
    va_list args2;
    if (tee_FILE) {
       va_copy(args2, args);
@@ -163,6 +179,7 @@ static int vprintf_wrapper(const char *str, va_list args)
 
 static ssize_t write_wrapper(int fd, const void *buffer, size_t size)
 {
+   typeof(&write) orig_write = gotcha_get_wrappee(orig_write_handle);
    if (fd != 1)
       return orig_write(fd, buffer, size);
    
@@ -173,6 +190,8 @@ static ssize_t write_wrapper(int fd, const void *buffer, size_t size)
 
 static int puts_wrapper(const char *str)
 {
+   typeof(&fputs) orig_fputs = gotcha_get_wrappee(orig_fputs_handle);
+   typeof(&puts) orig_puts = gotcha_get_wrappee(orig_puts_handle);
    if (tee_FILE) {
       orig_fputs(str, tee_FILE);
       orig_fputs("\n", tee_FILE);
@@ -182,6 +201,7 @@ static int puts_wrapper(const char *str)
 
 static int fputs_wrapper(const char *str, FILE *f)
 {
+   typeof(&fputs) orig_fputs = gotcha_get_wrappee(orig_fputs_handle);
    if (f != stdout)
       return orig_fputs(str, f);
    if (tee_FILE)
@@ -191,6 +211,7 @@ static int fputs_wrapper(const char *str, FILE *f)
 
 static int fwrite_wrapper(const void *ptr, size_t size, size_t nmemb, FILE *stream)
 {
+   typeof(&fwrite) orig_fwrite = gotcha_get_wrappee(orig_fwrite_handle);
    if (stream != stdout) 
       return orig_fwrite(ptr, size, nmemb, stream);
    if (tee_FILE)

--- a/test/stack/tool1.c
+++ b/test/stack/tool1.c
@@ -23,14 +23,15 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
 static int retX_wrapper(int x);
 
-static int(*origRetX)(int) = 0x0;
+static gotcha_wrappee_handle_t origRetX_handle = 0x0;
 
 #define NUM_IOFUNCS 1
 struct gotcha_binding_t iofuncs[] = {
-   { "retX",retX_wrapper,&origRetX}
+   { "retX",retX_wrapper,&origRetX_handle}
 };
 
 int retX_wrapper(int x){
+  typeof(&retX_wrapper) origRetX = gotcha_get_wrappee(origRetX_handle);
   printf("In tool1 wrapper, calling %p\n", origRetX);
   return origRetX ? (origRetX(x) + 1) : 0;
 }

--- a/test/stack/tool2.c
+++ b/test/stack/tool2.c
@@ -23,14 +23,15 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
 __attribute__((unused)) static int retX_wrapper(int x);
 
-static int(*origRetX)(int) = 0x0;
+static gotcha_wrappee_handle_t origRetX_handle = 0x0;
 
 #define NUM_IOFUNCS 1
 struct gotcha_binding_t iofuncs2[] = {
-   { "retX",retX_wrapper,&origRetX}
+   { "retX",retX_wrapper,&origRetX_handle}
 };
 
 int retX_wrapper(int x){
+  typeof(&retX_wrapper) origRetX = gotcha_get_wrappee(origRetX_handle);
   printf("In tool2 wrapper, calling %p\n", origRetX);
   return origRetX ? (origRetX(x) + 2) : 0;
 }

--- a/test/unit/gotcha_unit_tests.c
+++ b/test/unit/gotcha_unit_tests.c
@@ -63,8 +63,10 @@ extern int gotcha_prepare_symbols(binding_t *bindings, int num_names);
 
 int dummy_main(int argc, char* argv[]){return argv[argc-1][0];} //this is junk, will not be executed
 
-int(*orig_func)();
+//int(*orig_func)();
+gotcha_wrappee_handle_t orig_func_handle;
 int wrap_sample_func(){
+  typeof(&wrap_sample_func) orig_func = gotcha_get_wrappee(orig_func_handle);
   return orig_func()+5;
 }
 
@@ -80,7 +82,7 @@ END_TEST
 
 START_TEST(symbol_wrap_test){
   struct gotcha_binding_t bindings[] = {
-    { "simpleFunc", &wrap_sample_func, &orig_func }
+    { "simpleFunc", &wrap_sample_func, &orig_func_handle }
   };
   gotcha_wrap(bindings,1,"internal_test_tool");
   int x = simpleFunc(); 
@@ -90,7 +92,7 @@ END_TEST
 
 START_TEST(bad_lookup_test){
   struct gotcha_binding_t bindings[] = {
-    { "this_is_the_story_of_a_function_we_shouldnt_find", &wrap_sample_func, &orig_func }
+    { "this_is_the_story_of_a_function_we_shouldnt_find", &wrap_sample_func, &orig_func_handle }
   };
   enum gotcha_error_t errcode = gotcha_wrap(bindings,1,"internal_test_tool");
   ck_assert_msg((errcode==GOTCHA_FUNCTION_NOT_FOUND),"Looked up a function that shouldn't be found and did not get correct error code");

--- a/test/unit/gotcha_unit_tests.c
+++ b/test/unit/gotcha_unit_tests.c
@@ -63,7 +63,6 @@ extern int gotcha_prepare_symbols(binding_t *bindings, int num_names);
 
 int dummy_main(int argc, char* argv[]){return argv[argc-1][0];} //this is junk, will not be executed
 
-//int(*orig_func)();
 gotcha_wrappee_handle_t orig_func_handle;
 int wrap_sample_func(){
   typeof(&wrap_sample_func) orig_func = gotcha_get_wrappee(orig_func_handle);


### PR DESCRIPTION
Worth mentioning:

1. This version just [returns the handle](https://github.com/LLNL/GOTCHA/compare/develop...DavidPoliakoff:feature/indirection?expand=1#diff-205e643fae7d2554f79d6c4ec950de29R364), it doesn't implement a table yet. I don't know whether "it doesn't break user code" is a bug or a feature, but I suspect it's a bug

2) This version converts all of our tests. The most tedious part of what we're doing is that

3) This version *does* expose the C++ ugliness I feared. I have [one solution](https://github.com/LLNL/GOTCHA/compare/develop...DavidPoliakoff:feature/indirection?expand=1#diff-905dd2dbf285671fd8469e6c65a5f605), sure to make you fall in love with C++ all over again. I'm also not sure about how it's implemented, whether we want a separate C++ include file, or [just an "if I have C++" block in gotcha.h](https://github.com/LLNL/GOTCHA/compare/develop...DavidPoliakoff:feature/indirection?expand=1#diff-f9a83a8e236ad098da982ed6d2f62e95R125). I'm game to discuss why reinterpret_cast doesn't work, but calling a function which calls reinterpet_cast does, but this should work for our users.