### PR TITLE
WIP: Initial implementation on interface-independent wrapping

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 option(GOTCHA_ENABLE_TESTS "Enable internal tests" Off)
 option(GOTCHA_ENABLE_COVERAGE_TESTS "Enable coverage tests" Off)
-project(gotcha)
+project(gotcha C CXX ASM)
 include(CheckCXXCompilerFlag)
 include(cmake/gotcha.cmake)
 CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)

--- a/include/gotcha/gotcha.h
+++ b/include/gotcha/gotcha.h
@@ -72,6 +72,8 @@ extern "C" {
 GOTCHA_EXPORT enum gotcha_error_t gotcha_wrap(struct gotcha_binding_t* bindings, int num_actions, const char* tool_name);
 
 
+GOTCHA_EXPORT enum gotcha_error_t gotcha_sigfree_wrap(struct gotcha_sigfree_binding_t *bindings, int num_actions, const char *tool_name);
+
 /*!
  ******************************************************************************
  *
@@ -117,6 +119,19 @@ GOTCHA_EXPORT enum gotcha_error_t gotcha_get_priority(const char* tool_name, int
  ******************************************************************************
  */
 GOTCHA_EXPORT void* gotcha_get_wrappee(gotcha_wrappee_handle_t handle);
+
+/*!
+ ******************************************************************************
+ *
+ * \fn enum void* gotcha_get_wrappee_name(gotcha_wrappee_handle_t)
+ *
+ * \brief Given a GOTCHA wrapper's handle, returns the name of the wrappee function 
+ *
+ * \param handle The wrappee handle to return the name for
+ *
+ ******************************************************************************
+ */   
+GOTCHA_EXPORT const char* gotcha_get_wrappee_name(gotcha_wrappee_handle_t handle);
 
 #if defined(__cplusplus) 
 }

--- a/include/gotcha/gotcha_types.h
+++ b/include/gotcha/gotcha_types.h
@@ -30,6 +30,9 @@ extern "C" {
 
 typedef void* gotcha_wrappee_handle_t;
 
+typedef void (*sigfree_pre_wrapper_t)(gotcha_wrappee_handle_t handle, void **opaque_val);
+typedef void (*sigfree_post_wrapper_t)(gotcha_wrappee_handle_t handle, void *opaque_val);
+   
 /*!
  * The representation of a Gotcha action
  * as it passes through the pipeline
@@ -37,9 +40,16 @@ typedef void* gotcha_wrappee_handle_t;
 typedef struct gotcha_binding_t {
   const char* name;                                //!< The name of the function being wrapped
   void* wrapper_pointer;                           //!< A pointer to the wrapper function
-  gotcha_wrappee_handle_t* function_handle;         //!< A pointer to the function being wrapped
+  gotcha_wrappee_handle_t* function_handle;         //!< A handle to the function being wrapped
 }gotcha_binding_t;
 
+typedef struct gotcha_sigfree_binding_t {
+   const char *name;                              //!< The name of the function being wrapped
+   sigfree_pre_wrapper_t pre_wrapper;             //!< A pointer to the pre-wrapper function
+   sigfree_post_wrapper_t post_wrapper;           //!< A pointer to the post-wrapper function
+   gotcha_wrappee_handle_t *function_handle;       //!< A handle for referring to this wrapping
+} gotcha_sigfree_binding_t;
+   
 /*!
  * The representation of an error (or success) of a Gotcha action
  */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,8 @@ set(GOTCHA_SOURCES
   library_filters.c
   gotcha_dl.c
   translations.c
+  thin.c
+  thin_x86.s
 )
 
 add_library(gotcha SHARED ${GOTCHA_SOURCES})

--- a/src/thin.c
+++ b/src/thin.c
@@ -1,0 +1,165 @@
+/*
+This file is part of GOTCHA.  For copyright information see the COPYRIGHT
+file in the top level directory, or at
+https://github.com/LLNL/gotcha/blob/master/COPYRIGHT
+This program is free software; you can redistribute it and/or modify it under
+the terms of the GNU Lesser General Public License (as published by the Free
+Software Foundation) version 2.1 dated February 1999.  This program is
+distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the IMPLIED WARRANTY OF MERCHANTABILITY or FITNESS FOR A PARTICULAR
+PURPOSE. See the terms and conditions of the GNU Lesser General Public License
+for more details.  You should have received a copy of the GNU Lesser General
+Public License along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+*/
+
+#include <stdlib.h>
+#include "thin.h"
+#include "libc_wrappers.h"
+#include "tool.h"
+
+#define INITIAL_SAVESTATE_SIZE 128
+static __thread void *savestate = NULL;
+
+typedef struct {
+   void *stack_location;
+   void *retaddr;
+   void *opaque_handle;
+   void *unused;
+} stacksave_entry_t;
+
+typedef struct {
+   unsigned long savesize;
+   unsigned long cursize;
+   void *unused;
+   void *unused2;
+} stacksave_info_t;
+
+static void grow_stackstate(unsigned long newsize)
+{
+   stacksave_info_t *oldstack = (stacksave_info_t *) savestate;
+   unsigned long oldsize;
+   stacksave_info_t *newstack;
+
+   newstack = (stacksave_info_t *) gotcha_malloc(newsize * sizeof(stacksave_info_t));
+   newstack->savesize = newsize;
+   savestate = (void *) newstack;   
+   if (!oldstack) {
+      newstack->cursize = 1;
+      return;
+   }
+   
+   oldsize = oldstack->cursize;
+   memcpy(newstack, oldstack, oldsize * sizeof(stacksave_entry_t));
+   gotcha_free(oldstack);
+   savestate = (void *) newstack;
+}
+
+static void push_stack_addr(void **addr, void *opaque_handle)
+{
+   unsigned long cur;
+   stacksave_info_t *info = NULL;
+   stacksave_entry_t *entries;
+   if (!savestate) {
+      grow_stackstate(INITIAL_SAVESTATE_SIZE);
+   }
+   info = (stacksave_info_t *) savestate;
+   if (info->savesize == info->cursize) {
+      grow_stackstate(info->savesize * 2);
+      info = (stacksave_info_t *) savestate;
+   }
+   entries = (stacksave_entry_t *) savestate;
+   assert(info->cursize >= 1);
+   assert(info->cursize < info->savesize);
+   cur = info->cursize;
+   while ((cur != 1) && (entries[cur-1].stack_location <= (void *) addr))
+      cur--;
+   entries[cur].stack_location = (void *) addr;
+   entries[cur].retaddr = *addr;
+   entries[cur].opaque_handle = opaque_handle;
+   entries[cur].unused = NULL;
+   info->cursize = cur+1;
+}
+
+static void* pop_stack_state(void **addr, void **opaque_handle)
+{
+   stacksave_info_t *info = (stacksave_info_t *) savestate;
+   stacksave_entry_t *entries = (stacksave_entry_t *) savestate;
+   int cur = info->cursize-1;
+   
+   while ((cur != 0) && (entries[cur].stack_location != (void *) addr)) {
+      cur--;
+   }
+   assert(cur);
+   info->cursize = cur;
+   *opaque_handle = entries[cur].opaque_handle;
+   return entries[cur].retaddr;
+}
+
+static void* pre(gotcha_binding_t *binding, void **retaddr)
+{
+   internal_binding_t *int_binding = *((internal_binding_t **) (binding->function_handle));
+   void *opaque_handle = NULL, *wrappee;
+   sigfree_pre_wrapper_t wrapper = int_binding->pre_wrapper;
+   if (wrapper) {
+      wrapper((gotcha_wrappee_handle_t *) int_binding, &opaque_handle);
+   }  
+   push_stack_addr(retaddr, opaque_handle);
+   wrappee = gotcha_get_wrappee(*binding->function_handle);
+   return wrappee;
+}
+
+static void post(gotcha_binding_t *binding, void **retaddr)
+{
+   void *orig_retaddr;
+   void *opaque_handle;
+   internal_binding_t *int_binding = *((internal_binding_t **) (binding->function_handle));
+
+   orig_retaddr = pop_stack_state(retaddr, &opaque_handle);
+   sigfree_post_wrapper_t wrapper = int_binding->post_wrapper;
+   if (wrapper) {
+      wrapper((gotcha_wrappee_handle_t *) int_binding, opaque_handle);
+   }
+   *retaddr = orig_retaddr;
+}
+
+void *create_thin_wrapper(gotcha_binding_t *binding, void *tramp_memory, int binding_num)
+{
+   return create_trampoline(pre, post, binding, tramp_memory, binding_num);
+}
+
+extern unsigned char snippet_start, snippet_end;
+
+void *allocate_trampoline_memory(int entries)
+{
+   void *mem;
+   size_t size;
+   size = (size_t) (&snippet_end - &snippet_start);
+   size *= entries;
+   mem = mmap(NULL, size, PROT_EXEC | PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, 0, 0);
+   if (mem == MAP_FAILED)
+      return NULL;
+   return mem;
+}
+
+void *create_trampoline(void *prewrapper, void *postwrapper, void *param, void *trampmem, int num)
+{
+   unsigned char *mem;
+   size_t size, i;
+
+   size = (size_t) (&snippet_end - &snippet_start);
+   
+   mem = ((unsigned char *) trampmem) + (num * size);
+   memcpy(mem, &snippet_start, size);
+
+   for (i = 0; i < size-8; i++) {
+      if (*((unsigned long *) (mem + i)) == 0x1111111111111111)
+         memcpy(mem + i, &prewrapper, 8);
+      if (*((unsigned long *) (mem + i)) == 0x2222222222222222)
+         memcpy(mem + i, &param, 8);
+      if (*((unsigned long *) (mem + i)) == 0x3333333333333333)
+         memcpy(mem + i, &postwrapper, 8);
+   }
+
+   return mem;
+}

--- a/src/thin.h
+++ b/src/thin.h
@@ -1,0 +1,26 @@
+/*
+This file is part of GOTCHA.  For copyright information see the COPYRIGHT
+file in the top level directory, or at
+https://github.com/LLNL/gotcha/blob/master/COPYRIGHT
+This program is free software; you can redistribute it and/or modify it under
+the terms of the GNU Lesser General Public License (as published by the Free
+Software Foundation) version 2.1 dated February 1999.  This program is
+distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the IMPLIED WARRANTY OF MERCHANTABILITY or FITNESS FOR A PARTICULAR
+PURPOSE. See the terms and conditions of the GNU Lesser General Public License
+for more details.  You should have received a copy of the GNU Lesser General
+Public License along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+*/
+
+#if !defined(THIN_H_)
+#define THIN_H_
+
+#include "gotcha/gotcha.h"
+#include "tool.h"
+
+void *create_trampoline(void *prewrapper, void *postwrapper, void *param, void *tramp_memory, int num);
+void *create_thin_wrapper(gotcha_binding_t *binding, void *tramp_memory, int binding_num);
+void *allocate_trampoline_memory(int num_actions);
+
+#endif

--- a/src/thin_x86.s
+++ b/src/thin_x86.s
@@ -1,0 +1,39 @@
+   .text
+   .globl snippet_start
+   .globl snippet_end
+   
+snippet_start:
+   pushq %rsi
+   lea 8(%rsp), %rsi           
+   pushq %rax
+   pushq %rdi
+   pushq %rcx
+   pushq %rdx
+   pushq %r8
+   pushq %r9
+   movq $0x2222222222222222,%rdi
+   movq $0x1111111111111111,%rax
+   call *%rax
+   movq %rax,%r11
+   popq %r9
+   popq %r8
+   popq %rdx
+   popq %rcx
+   popq %rdi
+   popq %rax
+   popq %rsi
+   addq $8,%rsp
+   callq *%r11
+   subq $8,%rsp
+   movq %rsp,%rsi
+   movq $0x2222222222222222,%rdi
+   pushq %rax
+   pushq %rdx
+   movq $0x3333333333333333,%rax
+   callq *%rax
+   popq %rdx
+   popq %rax
+   ret
+snippet_end:
+   nop
+   

--- a/src/tool.c
+++ b/src/tool.c
@@ -94,17 +94,19 @@ tool_t *get_tool(const char *tool_name)
    return NULL;
 }
 
-binding_t *add_binding_to_tool(tool_t *tool, struct gotcha_binding_t *user_binding, int user_binding_size)
+binding_t *add_binding_to_tool(tool_t *tool, struct gotcha_binding_t *user_binding, gotcha_sigfree_binding_t *sigfree, int user_binding_size)
 {
    binding_t *newbinding;
    int result, i;
    newbinding = (binding_t *) gotcha_malloc(sizeof(binding_t));
    newbinding->tool = tool;
-   struct internal_binding_t* internal_bindings = (struct internal_binding_t*)gotcha_malloc(sizeof(struct internal_binding_t)*user_binding_size);
+   struct internal_binding_t* internal_bindings = (struct internal_binding_t*)gotcha_malloc(sizeof(struct internal_binding_t) * user_binding_size);
    for(i=0;i<user_binding_size;i++){
       internal_bindings[i].user_binding = &user_binding[i];
       *(user_binding[i].function_handle) = &internal_bindings[i];
       internal_bindings[i].associated_binding_table = newbinding;
+      internal_bindings[i].pre_wrapper = sigfree ? sigfree[i].pre_wrapper : NULL;
+      internal_bindings[i].post_wrapper = sigfree ? sigfree[i].post_wrapper : NULL;
    }  
    newbinding->internal_bindings = internal_bindings;
    newbinding->internal_bindings_size = user_binding_size;

--- a/src/tool.h
+++ b/src/tool.h
@@ -80,12 +80,14 @@ typedef struct tool_t {
    struct tool_t * parent_tool;
 } tool_t;
 
-struct internal_binding_t {
+typedef struct internal_binding_t {
   struct binding_t* associated_binding_table;
   struct gotcha_binding_t* user_binding;
   struct internal_binding_t* next_binding;
+  sigfree_pre_wrapper_t pre_wrapper;
+  sigfree_post_wrapper_t post_wrapper;
   void* wrappee_pointer;
-};
+} internal_binding_t;
 
 tool_t *create_tool(const char *tool_name);
 tool_t *get_tool(const char *tool_name);
@@ -94,7 +96,7 @@ void reorder_tool(tool_t* new_tool);
 void remove_tool_from_list(struct tool_t* target);
 void print_tools();
 
-binding_t *add_binding_to_tool(tool_t *tool, struct gotcha_binding_t *user_binding, int user_binding_size);
+binding_t *add_binding_to_tool(tool_t *tool, struct gotcha_binding_t *user_binding, gotcha_sigfree_binding_t *sigfree_bindings, int user_binding_size);
 binding_t *get_bindings();
 binding_t *get_tool_bindings(tool_t *tool);
 

--- a/test/unit/gotcha_unit_tests.c
+++ b/test/unit/gotcha_unit_tests.c
@@ -19,6 +19,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 #include <check.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <assert.h>
 
 #include "gotcha/gotcha.h"
 #include "testing_lib.h"


### PR DESCRIPTION
An initial implementation of interface-independent wrapping, for feedback purposes.  Use the new gotcha_sigfree_wrap() to wrap with pre/post wrappers that are independent of a function's signature, as discussed in #55.

Before merging this needs debugging prints, more tests, ppc64 support, and documentation.

This will also be complimented with a new gotcha query interface for listing libraries/symbols, which will allow one to do operations like wrap all functions exported from an arbitrary library.