### PR TITLE
fix string overrun

### DIFF
--- a/src/gotcha_auxv.c
+++ b/src/gotcha_auxv.c
@@ -98,7 +98,7 @@ struct link_map *get_vdso_from_auxv()
    parse_auxv_contents();
    if (!vdso_ehdr)
       return NULL;
-   
+
    vdso_phdrs = (ElfW(Phdr) *) (vdso_ehdr->e_phoff + ((unsigned char *) vdso_ehdr));
    vdso_phdr_num = vdso_ehdr->e_phnum;
 
@@ -188,7 +188,7 @@ static int read_hex(char *str, unsigned long *val)
    }
 }
 
-static int read_word(char *str, char *word, int word_size) 
+static int read_word(char *str, char *word, int word_size)
 {
    int word_cur = 0;
    int len = 0;
@@ -223,11 +223,11 @@ struct link_map *get_vdso_from_maps()
 {
    int maps, hit_eof;
    ElfW(Addr) addr_begin, addr_end, dynamic;
-   char name[4096], line[4096], *line_pos;
+   char name[4096], line[4097], *line_pos;
    struct link_map *m;
    maps = gotcha_open("/proc/self/maps", O_RDONLY);
    for (;;) {
-      hit_eof = read_line(line, 4097, maps);
+      hit_eof = read_line(line, sizeof(line), maps);
       if (hit_eof) {
          gotcha_close(maps);
          return NULL;
@@ -254,7 +254,7 @@ struct link_map *get_vdso_from_maps()
       if (dynamic >= addr_begin && dynamic < addr_end)
          return m;
    }
-   
+
    return NULL;
 }
 
@@ -268,7 +268,7 @@ int is_vdso(struct link_map *map)
       return 0;
    if (vdso_checked)
       return (map == vdso);
-   
+
    vdso_checked = 1;
 
    result = get_vdso_from_aliases();


### PR DESCRIPTION
- Fixed a warning I found: `read_line` does: `line[size - 1] = '\0';` but was this: `char line[4096]; ...; read_line(line, 4097, ...)`. I assumed you wanted to allow 4096 characters in a line and thus, needed an array of 4097 for the terminator.
