### PR TITLE
Workaround for glibc v2.34+ not exporting _dl_sym

### DIFF
--- a/src/gotcha_dl.c
+++ b/src/gotcha_dl.c
@@ -5,7 +5,16 @@
 #include "elf_ops.h"
 #include <dlfcn.h>
 
-void* _dl_sym(void* handle, const char* name, void* where);
+#if defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 34
+#    define GOTCHA_DL_SYM_WORKAROUND 1
+#endif
+
+#if defined(GOTCHA_DL_SYM_WORKAROUND)
+static void* (*gotcha_dlsym_internal)(void*, const char*);
+#else
+void*
+_dl_sym(void* handle, const char* name, void* where);
+#endif
 
 gotcha_wrappee_handle_t orig_dlopen_handle;
 gotcha_wrappee_handle_t orig_dlsym_handle;
@@ -17,13 +26,13 @@ static int per_binding(hash_key_t key, hash_data_t data, void *opaque KNOWN_UNUS
 
    debug_printf(3, "Trying to re-bind %s from tool %s after dlopen\n",
                 binding->user_binding->name, binding->associated_binding_table->tool->tool_name);
-   
+
    while (binding->next_binding) {
       binding = binding->next_binding;
       debug_printf(3, "Selecting new innermost version of binding %s from tool %s.\n",
                    binding->user_binding->name, binding->associated_binding_table->tool->tool_name);
    }
-   
+
    result = prepare_symbol(binding);
    if (result == -1) {
       debug_printf(3, "Still could not prepare binding %s after dlopen\n", binding->user_binding->name);
@@ -45,7 +54,7 @@ static void* dlopen_wrapper(const char* filename, int flags) {
 
    debug_printf(2, "Updating GOT entries for new dlopened libraries\n");
    update_all_library_gots(&function_hash_table);
-  
+
    return handle;
 }
 
@@ -55,13 +64,23 @@ static void* dlsym_wrapper(void* handle, const char* symbol_name){
   int result;
   debug_printf(1, "User called dlsym(%p, %s)\n", handle, symbol_name);
 
-  if(handle == RTLD_NEXT){
-    return _dl_sym(RTLD_NEXT, symbol_name ,__builtin_return_address(0));
+  if(handle == RTLD_NEXT)
+  {
+#if defined(GOTCHA_DL_SYM_WORKAROUND)
+      return (*gotcha_dlsym_internal)(RTLD_NEXT, symbol_name);
+#else
+      return _dl_sym(RTLD_NEXT, symbol_name, __builtin_return_address(0));
+#endif
   }
-  if(handle == RTLD_DEFAULT) {
-    return _dl_sym(RTLD_DEFAULT, symbol_name,__builtin_return_address(0));
+  else if(handle == RTLD_DEFAULT)
+  {
+#if defined(GOTCHA_DL_SYM_WORKAROUND)
+      return (*gotcha_dlsym_internal)(RTLD_DEFAULT, symbol_name);
+#else
+      return _dl_sym(RTLD_DEFAULT, symbol_name, __builtin_return_address(0));
+#endif
   }
-  
+
   result = lookup_hashtable(&function_hash_table, (hash_key_t) symbol_name, (hash_data_t *) &binding);
   if (result == -1)
      return orig_dlsym(handle, symbol_name);
@@ -72,8 +91,25 @@ static void* dlsym_wrapper(void* handle, const char* symbol_name){
 struct gotcha_binding_t dl_binds[] = {
   {"dlopen", dlopen_wrapper, &orig_dlopen_handle},
   {"dlsym", dlsym_wrapper, &orig_dlsym_handle}
-};     
-void handle_libdl(){
-  gotcha_wrap(dl_binds, 2, "gotcha");
-}
+};
 
+void
+handle_libdl()
+{
+#if defined(GOTCHA_DL_SYM_WORKAROUND)
+    void* libdl_handle = dlopen("libdl.so", RTLD_LAZY | RTLD_LOCAL);
+    if(libdl_handle == NULL)
+    {
+        error_printf("Failed to dlopen libdl.so :: dlsym with RTLD_DEFAULT or RTLD_NEXT "
+                     "as the handle will fail.\n");
+    }
+    else
+    {
+        gotcha_dlsym_internal = dlsym(libdl_handle, "dlsym");
+        if(gotcha_dlsym_internal == NULL)
+            error_printf("Failed to dlsym the dlysm function in libdl.so :: dlsym with "
+                         "RTLD_DEFAULT or RTLD_NEXT as the handle will fail.\n");
+    }
+#endif
+    gotcha_wrap(dl_binds, 2, "gotcha");
+}

--- a/test/dlopen/CMakeLists.txt
+++ b/test/dlopen/CMakeLists.txt
@@ -9,3 +9,16 @@ environment_add(dlopen_test TEST "GOTCHA_DEBUG=3 LIBNUM_DIR=${CMAKE_CURRENT_BINA
 set_tests_properties(dlopen_test PROPERTIES
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
+
+add_library(num2 SHARED num2.c)
+add_executable(test_dlopen2 test_dlopen2.c)
+set_target_properties(test_dlopen2
+  PROPERTIES COMPILE_FLAGS "-DLIB_NAME_RAW=\"\"${CMAKE_CURRENT_BINARY_DIR}/libnum.so\"\""
+    LINK_FLAGS "-Wl,-no-as-needed"
+  )
+target_link_libraries(test_dlopen2 gotcha dl num2)
+gotcha_add_test(dlopen_test2 test_dlopen2)
+environment_add(dlopen_test2 TEST "GOTCHA_DEBUG=3;LIBNUM_DIR=${CMAKE_CURRENT_BINARY_DIR}")
+set_tests_properties(dlopen_test2 PROPERTIES
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+)

--- a/test/dlopen/num2.c
+++ b/test/dlopen/num2.c
@@ -1,0 +1,20 @@
+/*
+This file is part of GOTCHA.  For copyright information see the COPYRIGHT
+file in the top level directory, or at
+https://github.com/LLNL/gotcha/blob/master/COPYRIGHT
+This program is free software; you can redistribute it and/or modify it under
+the terms of the GNU Lesser General Public License (as published by the Free
+Software Foundation) version 2.1 dated February 1999.  This program is
+distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the IMPLIED WARRANTY OF MERCHANTABILITY or FITNESS FOR A PARTICULAR
+PURPOSE. See the terms and conditions of the GNU Lesser General Public License
+for more details.  You should have received a copy of the GNU Lesser General
+Public License along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+*/
+
+int return_five()
+{
+    /* Intentional bug, RTLD_NEXT should return this */
+    return 6;
+}

--- a/test/dlopen/test_dlopen2.c
+++ b/test/dlopen/test_dlopen2.c
@@ -1,0 +1,132 @@
+/*
+This file is part of GOTCHA.  For copyright information see the COPYRIGHT
+file in the top level directory, or at
+https://github.com/LLNL/gotcha/blob/master/COPYRIGHT
+This program is free software; you can redistribute it and/or modify it under
+the terms of the GNU Lesser General Public License (as published by the Free
+Software Foundation) version 2.1 dated February 1999.  This program is
+distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the IMPLIED WARRANTY OF MERCHANTABILITY or FITNESS FOR A PARTICULAR
+PURPOSE. See the terms and conditions of the GNU Lesser General Public License
+for more details.  You should have received a copy of the GNU Lesser General
+Public License along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+*/
+
+#define _GNU_SOURCE
+#include "gotcha/gotcha.h"
+
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define Q(x) #x
+#define QUOTE(x) Q(x)
+
+#ifndef LIB_NAME_RAW
+#    define LIB_NAME_RAW libnum.so
+#endif
+
+#define LIB_NAME QUOTE(LIB_NAME_RAW)
+
+int
+correct_return_four()
+{
+    return 4;
+}
+
+int
+return_five()
+{
+    /* Intentional bug, gotcha will correct this to return 5*/
+    return 3;
+}
+
+int
+correct_return_five()
+{
+    return 5;
+}
+
+static gotcha_wrappee_handle_t buggy_return_four;
+static gotcha_wrappee_handle_t buggy_return_five;
+struct gotcha_binding_t        funcs[] = {
+    { "return_four", correct_return_four, &buggy_return_four },
+    { "return_five", correct_return_five, &buggy_return_five }
+};
+
+int
+main()
+{
+    void* libnum              = NULL;
+    int (*retfour)(void)      = NULL;
+    int (*retfive)(void)      = NULL;
+    int (*test_retfive)(void) = NULL;
+    int had_error             = 0;
+    int result                = 0;
+
+    result = gotcha_wrap(funcs, 2, "dlopen_test");
+    if(result != GOTCHA_FUNCTION_NOT_FOUND)
+    {
+        fprintf(stderr, "GOTCHA should have failed to find a function, but found it\n");
+        return -1;
+    }
+
+    libnum = dlopen(LIB_NAME, RTLD_NOW);
+    if(!libnum)
+    {
+        fprintf(stderr, "ERROR: Test failed to dlopen %s\n", LIB_NAME);
+        return -1;
+    }
+
+    /* Test 1: Check if a dlsym generated indirect call gets re-routed by gotcha */
+    retfour = (int (*)(void)) dlsym(libnum, "return_four");
+    if(retfour() != 4)
+    {
+        fprintf(stderr, "ERROR: dlsym returned original function, not wrapped\n");
+        had_error = -1;
+    }
+
+    /* Test 2: dlsym + RTLD_DEFAULT returns implementation in this file */
+    retfive = (int (*)(void)) dlsym(RTLD_DEFAULT, "return_five");
+    if(retfive == NULL)
+    {
+        fprintf(stderr,
+                "ERROR: dlsym(RTLD_DEFAULT, 'return_five') returned null pointer\n");
+        had_error = -1;
+    }
+    else if(retfive() != 3)
+    {
+        fprintf(stderr,
+                "ERROR: dlsym(RTLD_DEFAULT, 'return_five') returned the wrong symbol\n");
+        had_error = -1;
+    }
+
+    /* Test 3: dlsym + RTLD_NEXT returns implementation in num2.c */
+    retfive = (int (*)(void)) dlsym(RTLD_NEXT, "return_five");
+    if(retfive == NULL)
+    {
+        fprintf(stderr, "ERROR: dlsym(RTLD_NEXT, 'return_five') returned null pointer\n");
+        had_error = -1;
+    }
+    else if(retfive() != 6)
+    {
+        fprintf(stderr,
+                "ERROR: dlsym(RTLD_NEXT, 'return_five') returned the wrong symbol\n");
+        had_error = -1;
+    }
+
+    /* Test 4: Does a call in a dlopen'd library get rerouted by gotcha */
+    test_retfive = (int (*)(void)) dlsym(libnum, "test_return_five");
+    if(test_retfive() != 5)
+    {
+        fprintf(stderr,
+                "ERROR: call to return_five in %s was not wrapped by "
+                "correct_return_five\n",
+                LIB_NAME);
+        had_error = -1;
+    }
+
+    return had_error;
+}


### PR DESCRIPTION
- added test_dlopen2 test validating RTLD_DEFAULT and RTLD_NEXT usage
- closes #100 

@mplegendre I believe this relatively straight-forward solution addresses the issue -- am I missing something here? I separated it out to only be applied when glibc >= 2.34 but it works fine with older versions of glibc.