### PR TITLE
fix dlsym issue for glibc >= 2.34

### DIFF
--- a/src/gotcha_dl.c
+++ b/src/gotcha_dl.c
@@ -5,7 +5,95 @@
 #include "elf_ops.h"
 #include <dlfcn.h>
 
-void* _dl_sym(void* handle, const char* name, void* where);
+/**
+ * structure used to pass lookup addr and return library address.
+ */
+struct Addrs {
+    ElfW(Addr) lookup_addr; // input
+    struct link_map *lmap;  // output
+    int found;
+};
+/**
+ * This is a callback to get headers for each library.
+ * We check if the caller's virtual address is between base address and the virtual addr + memory size.
+ * Then we select the lmap based on base_addr and name
+ *
+ * @param info, information about headers
+ * @param size, size of headers
+ * @param data, data from caller
+ * @return
+ */
+int lib_header_callback(struct dl_phdr_info * info, size_t size, void * data) {
+    struct Addrs* addrs = data;
+    char *name = NULL;
+    ElfW(Addr) load_address;
+    for (int i = 0; i < info->dlpi_phnum; ++i) {
+        if (info->dlpi_phdr[i].p_type == PT_LOAD) {
+            ElfW(Addr) base_addr = info->dlpi_addr;
+            ElfW(Addr) start_addr = base_addr + info->dlpi_phdr[i].p_vaddr;
+            ElfW(Addr) end_addr = start_addr + info->dlpi_phdr[i].p_memsz;
+            if (addrs->lookup_addr >= start_addr && addrs->lookup_addr < end_addr) {
+                name = info->dlpi_name;
+                load_address = info->dlpi_addr;
+                break;
+            }
+        }
+    }
+    if (name) {
+        struct link_map *current = addrs->lmap;
+        while (current) {
+            if (strcmp(current->l_name, name) == 0 && load_address == current->l_addr) {
+                addrs->lmap = current;
+                addrs->found = 1;
+                return 1;
+            }
+            current = current->l_next;
+        }
+    }
+    return 0;
+}
+
+/**
+ * Implement the logic of _dl_sym for supporting RTLD_NEXT
+ * 1. find the caller library using the program headers.
+ * 2. find the second library which has the symbol for RTLD_NEXT
+ * @param handle, handle for dl operation
+ * @param name, name of the symbol
+ * @param who, the virtual address of the caller
+ * @return link_map pointer
+ */
+
+static struct link_map* gotchas_dlsym_rtld_next_lookup(const char *name, void *who) {
+    ElfW(Addr) caller = (ElfW(Addr)) who;
+    /* Iterative over the library headers and find the caller
+     * the address of the caller is set in addrs->library_laddr
+     **/
+    struct Addrs addrs;
+    addrs.lookup_addr = caller;
+    addrs.lmap = _r_debug.r_map;
+    addrs.found = 0;
+    void* symbol;
+    dl_iterate_phdr(lib_header_callback, &addrs);
+    if (!addrs.found) {
+        error_printf("RTLD_NEXT used in code not dynamically loaded");
+        exit (127);
+    }
+    struct link_map *handle = addrs.lmap->l_next;
+    while(handle) {
+        /* lookup symbol on the next-to-next lib which has symbol
+         * for RTLD_NEXT
+         **/
+        long result = lookup_exported_symbol(name, handle, &symbol);
+        if (result != -1) {
+            return handle;
+        } else {
+            debug_printf(3, "Symbol %s not found in the library %s\n", name, LIB_NAME(handle));
+        }
+        handle = handle->l_next;
+    }
+    debug_printf(3, "Symbol %s not found in the libraries after caller\n", name);
+    return NULL;
+}
 
 gotcha_wrappee_handle_t orig_dlopen_handle;
 gotcha_wrappee_handle_t orig_dlsym_handle;
@@ -52,21 +140,20 @@ static void* dlopen_wrapper(const char* filename, int flags) {
 static void* dlsym_wrapper(void* handle, const char* symbol_name){
   typeof(&dlsym_wrapper) orig_dlsym = gotcha_get_wrappee(orig_dlsym_handle);
   struct internal_binding_t *binding;
-  int result;
   debug_printf(1, "User called dlsym(%p, %s)\n", handle, symbol_name);
-
+  int result = lookup_hashtable(&function_hash_table, (hash_key_t) symbol_name, (hash_data_t *) &binding);
+  if (result != -1) return binding->user_binding->wrapper_pointer;
   if(handle == RTLD_NEXT){
-    return _dl_sym(RTLD_NEXT, symbol_name ,__builtin_return_address(0));
+    struct link_map* lib = gotchas_dlsym_rtld_next_lookup(symbol_name ,__builtin_return_address(0));
+    if (lib) {
+        void* symbol = orig_dlsym(lib, symbol_name);
+        return symbol;
+    }
+    return NULL;
+  } else {
+      return orig_dlsym(handle, symbol_name);
   }
-  if(handle == RTLD_DEFAULT) {
-    return _dl_sym(RTLD_DEFAULT, symbol_name,__builtin_return_address(0));
-  }
-  
-  result = lookup_hashtable(&function_hash_table, (hash_key_t) symbol_name, (hash_data_t *) &binding);
-  if (result == -1)
-     return orig_dlsym(handle, symbol_name);
-  else
-     return binding->user_binding->wrapper_pointer;
+
 }
 
 struct gotcha_binding_t dl_binds[] = {

--- a/src/gotcha_dl.h
+++ b/src/gotcha_dl.h
@@ -6,6 +6,7 @@
 
 void handle_libdl();
 extern void update_all_library_gots(hash_table_t *bindings);
+extern long lookup_exported_symbol(const char* name, const struct link_map *lib, void** symbol);
 extern int prepare_symbol(struct internal_binding_t *binding);
 
 extern gotcha_wrappee_handle_t orig_dlopen_handle;

--- a/test/dlopen/CMakeLists.txt
+++ b/test/dlopen/CMakeLists.txt
@@ -1,9 +1,11 @@
 add_library(num SHARED num.c)
+add_library(num2 SHARED num2.c)
 add_executable(test_dlopen test_dlopen.c)
 set_target_properties(test_dlopen
-  PROPERTIES COMPILE_FLAGS "-DLIB_NAME_RAW=\"\"${CMAKE_CURRENT_BINARY_DIR}/libnum.so\"\""
+  PROPERTIES COMPILE_FLAGS "-DLIB_NAME_RAW=\"\"${CMAKE_CURRENT_BINARY_DIR}/libnum.so\"\" -DLIB2_NAME_RAW=\"\"${CMAKE_CURRENT_BINARY_DIR}/libnum2.so\"\""
   )
 target_link_libraries(test_dlopen gotcha dl)
+add_dependencies(test_dlopen num num2)
 gotcha_add_test(dlopen_test test_dlopen)
 environment_add(dlopen_test TEST "GOTCHA_DEBUG=3 LIBNUM_DIR=${CMAKE_CURRENT_BINARY_DIR}")
 set_tests_properties(dlopen_test PROPERTIES

--- a/test/dlopen/num2.c
+++ b/test/dlopen/num2.c
@@ -1,0 +1,29 @@
+/*
+This file is part of GOTCHA.  For copyright information see the COPYRIGHT
+file in the top level directory, or at
+https://github.com/LLNL/gotcha/blob/master/COPYRIGHT
+This program is free software; you can redistribute it and/or modify it under
+the terms of the GNU Lesser General Public License (as published by the Free
+Software Foundation) version 2.1 dated February 1999.  This program is
+distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the IMPLIED WARRANTY OF MERCHANTABILITY or FITNESS FOR A PARTICULAR
+PURPOSE. See the terms and conditions of the GNU Lesser General Public License
+for more details.  You should have received a copy of the GNU Lesser General
+Public License along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+*/
+
+extern void mark_had_error();
+extern int return_five();
+
+int return_four()
+{
+   return 4;
+}
+
+int test_return_five()
+{
+   return return_five();
+}
+
+


### PR DESCRIPTION
We get a compilation issue for newer kernels that use glibc >= 2.34 as _dl_sym is not exported. Fixes #100 

Re-Implement the logic of _dl_sym
 1. find the caller library using the program headers.
 2. find the first library which has the symbol for RTLD_DEFAULT
 3. find the second library which has the symbol for RTLD_NEXT