### PR TITLE
fixed install script for apps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,13 +37,14 @@ write_basic_package_version_file(
   COMPATIBILITY SameMajorVersion)
 
 set(gotcha_INSTALL_INCLUDE_DIR include/)
+set(gotcha_INSTALL_LIB_DIR lib/)
 
 # Configure gotcha-config.cmake
 configure_package_config_file(
   "cmake/config.cmake.in"
   "${CMAKE_CURRENT_BINARY_DIR}/gotcha-config.cmake"
   INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/gotcha"
-  PATH_VARS gotcha_INSTALL_INCLUDE_DIR)
+  PATH_VARS gotcha_INSTALL_INCLUDE_DIR PATH_VARS gotcha_INSTALL_LIB_DIR)
 
 install(
   FILES "${CMAKE_CURRENT_BINARY_DIR}/gotcha-config.cmake" "${CMAKE_CURRENT_BINARY_DIR}/gotcha-config-version.cmake"

--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -1,12 +1,13 @@
 @PACKAGE_INIT@
 
 set_and_check(gotcha_INCLUDE_DIR "@PACKAGE_gotcha_INSTALL_INCLUDE_DIR@")
+set_and_check(gotcha_LIBRARIES_DIR "@PACKAGE_gotcha_INSTALL_LIB_DIR@")
 
 if (NOT TARGET gotcha)
   include(${CMAKE_CURRENT_LIST_DIR}/gotcha-targets.cmake)
 endif()
 
 set(gotcha_INCLUDE_DIRS ${gotcha_INCLUDE_DIR})
-set(gotcha_LIBRARIES gotcha)
+set(gotcha_LIBRARIES "-L{gotcha_LIBRARIES_DIR} -lgotcha")
 
 check_required_components(gotcha)


### PR DESCRIPTION
As we do not export LIB PATH some libraries will be able to find package through cmake unless they hardcode their app to include LIB_PATH.