### PR TITLE
fixed install script for apps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ write_basic_package_version_file(
 
 set(gotcha_INSTALL_INCLUDE_DIR include/)
 set(gotcha_INSTALL_LIB_DIR lib/)
+set(gotcha_INSTALL_LIB64_DIR lib64/)
 
 # Configure gotcha-config.cmake
 configure_package_config_file(

--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -2,12 +2,13 @@
 
 set_and_check(gotcha_INCLUDE_DIR "@PACKAGE_gotcha_INSTALL_INCLUDE_DIR@")
 set_and_check(gotcha_LIBRARIES_DIR "@PACKAGE_gotcha_INSTALL_LIB_DIR@")
+set_and_check(gotcha_LIBRARIES64_DIR "@PACKAGE_gotcha_INSTALL_LIB64_DIR@")
 
 if (NOT TARGET gotcha)
   include(${CMAKE_CURRENT_LIST_DIR}/gotcha-targets.cmake)
 endif()
 
 set(gotcha_INCLUDE_DIRS ${gotcha_INCLUDE_DIR})
-set(gotcha_LIBRARIES "-L${gotcha_LIBRARIES_DIR} -lgotcha")
+set(gotcha_LIBRARIES "-L${gotcha_LIBRARIES_DIR} -L${gotcha_LIBRARIES64_DIR} -lgotcha")
 
 check_required_components(gotcha)


### PR DESCRIPTION
As we do not export LIB PATH some libraries will be able to find package through cmake unless they hardcode their app to include LIB_PATH.