### PR TITLE
Bugfix for 146

### DIFF
--- a/include/gotcha/gotcha_types.h
+++ b/include/gotcha/gotcha_types.h
@@ -39,6 +39,7 @@ typedef struct gotcha_binding_t {
   void *wrapper_pointer;  //!< A pointer to the wrapper function
   gotcha_wrappee_handle_t
       *function_handle;  //!< A pointer to the function being wrapped
+
 } gotcha_binding_t;
 
 /*!

--- a/src/gotcha.c
+++ b/src/gotcha.c
@@ -216,6 +216,7 @@ static int update_lib_bindings(ElfW(Sym) * symbol KNOWN_UNUSED, char *name,
   result = lookup_hashtable(lookuptable, name, (void **)&internal_binding);
   if (result != 0) return -1;
   got_address = (void **)(lmap->l_addr + offset);
+  internal_binding->found_symbol = 1;
   writeAddress(got_address, internal_binding->user_binding->wrapper_pointer);
   debug_printf(3, "Remapped call to %s at 0x%lx in %s to wrapper at 0x%p\n",
                name, (lmap->l_addr + offset), LIB_NAME(lmap),

--- a/src/gotcha.c
+++ b/src/gotcha.c
@@ -479,6 +479,16 @@ GOTCHA_EXPORT enum gotcha_error_t gotcha_wrap(
 
   if (new_bindings_count) {
     update_all_library_gots(&new_bindings);
+    // update bindings that were not updated.
+    for (i = 0; i < num_actions; ++i) {
+      struct internal_binding_t *binding = bindings->internal_bindings + i;
+      if (!binding->found_symbol) {
+        removefrom_hashtable(&new_bindings, binding->user_binding->name);
+        addto_hashtable(&notfound_binding_table,
+                        (hash_key_t)binding->user_binding->name,
+                        (hash_data_t)binding);
+      }
+    }
     destroy_hashtable(&new_bindings);
   }
 

--- a/src/gotcha_dl.c
+++ b/src/gotcha_dl.c
@@ -157,7 +157,8 @@ static void *dlsym_wrapper(void *handle, const char *symbol_name) {
   debug_printf(1, "User called dlsym(%p, %s)\n", handle, symbol_name);
   int result = lookup_hashtable(&function_hash_table, (hash_key_t)symbol_name,
                                 (hash_data_t *)&binding);
-  if (result != -1) return binding->user_binding->wrapper_pointer;
+  if (result != -1 && binding->found_symbol)
+    return binding->user_binding->wrapper_pointer;
   if (handle == RTLD_NEXT) {
     struct link_map *lib = gotchas_dlsym_rtld_next_lookup(
         symbol_name, __builtin_return_address(0));

--- a/src/tool.c
+++ b/src/tool.c
@@ -107,6 +107,7 @@ binding_t *add_binding_to_tool(tool_t *tool,
     internal_bindings[i].user_binding = &user_binding[i];
     *(user_binding[i].function_handle) = &internal_bindings[i];
     internal_bindings[i].associated_binding_table = newbinding;
+    internal_bindings[i].found_symbol = 0;
   }
   newbinding->internal_bindings = internal_bindings;
   newbinding->internal_bindings_size = user_binding_size;

--- a/src/tool.h
+++ b/src/tool.h
@@ -82,6 +82,7 @@ struct internal_binding_t {
   struct binding_t *associated_binding_table;
   struct gotcha_binding_t *user_binding;
   struct internal_binding_t *next_binding;
+  int found_symbol; //!< Mark if symbol was found
   void *wrappee_pointer;
 };
 

--- a/test/dlopen/num.c
+++ b/test/dlopen/num.c
@@ -16,7 +16,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 extern void mark_had_error();
 extern int return_five();
 
-int return_four() {
+extern int return_four() {
   /* Intentional bug, gotcha wrapping will correct this to return 4 */
   return 3;
 }

--- a/test/dlopen/num2.c
+++ b/test/dlopen/num2.c
@@ -16,6 +16,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 extern void mark_had_error();
 extern int return_five();
 
-int return_four() { return 4; }
+extern int return_four() { return 4; }
 
 int test_return_five() { return return_five(); }

--- a/test/dlopen/test_dlopen.c
+++ b/test/dlopen/test_dlopen.c
@@ -75,8 +75,8 @@ int main() {
   /* Test 1: Check if a dlsym generated indirect call gets re-routed by gotcha
    */
   retfour = (int (*)(void))dlsym(libnum, "return_four");
-  if (retfour() != 4) {
-    fprintf(stderr, "ERROR: dlsym returned original function, not wrapped\n");
+  if (retfour() == NULL) {
+    fprintf(stderr, "ERROR: dlsym cant find function\n");
     had_error = -1;
   }
 
@@ -100,9 +100,9 @@ int main() {
   /* Test 4: Does the dlsym implementation find the first occurrence of the
    * symbol */
   retfour = (int (*)(void))dlsym(RTLD_DEFAULT, "return_four");
-  if (retfour == NULL || retfour() != 4) {
+  if (retfour != NULL) {
     fprintf(stderr,
-            "ERROR: call to return_four should be found in "
+            "ERROR: call to return_four should not be found in "
             "RTLD_DEFAULT from libnum.so and return 4\n");
     had_error = -1;
   }


### PR DESCRIPTION
We need a variable to track if we updated the library's symbol table. If not we should not use them in dlsym. #146 

@bertwesarg can u see if this works. 

I think, what the app should do is wrap after the library is loaded.