### PR TITLE
Added a null check as we should not find null entries.

### DIFF
--- a/src/gotcha_dl.c
+++ b/src/gotcha_dl.c
@@ -113,6 +113,7 @@ static int per_binding(hash_key_t key, hash_data_t data,
                binding->user_binding->name,
                binding->associated_binding_table->tool->tool_name);
 
+  if (!binding->user_binding->name) return 0;
   while (binding->next_binding) {
     binding = binding->next_binding;  // GCOVR_EXCL_START
     debug_printf(3,


### PR DESCRIPTION
Currently, if we have non-wrapped functions and the gotcha bindings gets free, it leads to seg fault.

This PR adds a null check to avoid those cases.