### PR TITLE
Enable tool unwrap within GOTCHA.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 build
 tags
 **/tags
+*.core
+.cache
+.idea
+.vscode

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -83,6 +83,20 @@ If an tool uses multiple bindings then they have to set priority to different bi
     GOTCHA does not create a copy of the binding functions and is the responsibility of the user to maintain this binding.
 
 
+------------------------
+Unwrap the binding calls
+------------------------
+
+Remove the tool from GOTCHA wrapping to be used as a final routine.
+
+.. code-block:: c
+
+    gotcha_error_t gotcha_unwrap("my_tool_name");
+
+This will allow users to remove their tool. 
+In this case, GOTCHA will look for existing function bindings and move it to the next available tool. 
+If none, the binding would be simply removed.
+
 ----------------------------
 Set priority of tool binding
 ----------------------------

--- a/include/gotcha/gotcha.h
+++ b/include/gotcha/gotcha.h
@@ -125,11 +125,55 @@ GOTCHA_EXPORT enum gotcha_error_t gotcha_get_priority(const char *tool_name,
  */
 GOTCHA_EXPORT void *gotcha_get_wrappee(gotcha_wrappee_handle_t handle);
 
+/*!
+ * \fn void gotcha_filter_libraries_by_name(const char *nameFilter);
+ *
+ * \brief This API allows GOTCHA to include only libraries given specified by
+ * the user. This could be a partial match of string contains as defined by
+ * strstr function in C.
+ *
+ * \param nameFilter the filter name
+ */
 GOTCHA_EXPORT void gotcha_filter_libraries_by_name(const char *nameFilter);
+
+/*!
+ * \fn void gotcha_only_filter_last();
+ *
+ * \brief This API allows GOTCHA to include only the last library defined in the
+ * linker of the tool.
+ */
 GOTCHA_EXPORT void gotcha_only_filter_last();
+
+/*!
+ * \fn void gotcha_set_library_filter_func(int (*new_func)(struct link_map *));
+ *
+ * \brief This API allows users to define a function that selected the libraries
+ * that user wants to intercept. The function should take struct link_map* as
+ * input and return true if it should be wrapped by GOTCHA. TIP: the library
+ * name can be accessed by map->l_name.
+ *
+ * \param new_func has the function signature of int (*new_func)(struct link_map
+ * *)
+ */
 GOTCHA_EXPORT void gotcha_set_library_filter_func(
     int (*new_func)(struct link_map *));
+
+/*!
+ * \fn void gotcha_restore_library_filter_func();
+ *
+ * \brief The default filter of gotcha selects all libraries loaded. This
+ * function set the default filter back for GOTCHA.
+ */
 GOTCHA_EXPORT void gotcha_restore_library_filter_func();
+
+/*!
+ * \fn enum gotcha_error_t gotcha_unwrap(const char *tool_name);
+ *
+ * \brief remove the tool from GOTCHA wrapping to be used as a final routine.
+ *
+ * \param tool_name, The tool name to remove
+ */
+GOTCHA_EXPORT enum gotcha_error_t gotcha_unwrap(const char *tool_name);
 
 #if defined(__cplusplus)
 }

--- a/src/gotcha.c
+++ b/src/gotcha.c
@@ -537,6 +537,7 @@ GOTCHA_EXPORT void *gotcha_get_wrappee(gotcha_wrappee_handle_t handle) {
 }
 
 GOTCHA_EXPORT enum gotcha_error_t gotcha_unwrap(const char *tool_name) {
+  debug_printf(1, "Unwrapping Gotcha tool %s\n", tool_name);
   struct tool_t *tool_instance = get_tool(tool_name);
   if (tool_instance == NULL) return GOTCHA_INVALID_TOOL;
   for (int i = 0; i < tool_instance->binding->internal_bindings_size; i++) {
@@ -549,6 +550,7 @@ GOTCHA_EXPORT enum gotcha_error_t gotcha_unwrap(const char *tool_name) {
         lookup_hashtable(&function_hash_table, (void *)name, (void **)&head);
     if (hash_result == 0) {
       if (head == binding) {
+        debug_printf(1, "Found function %s wrapped by tool\n", name);
         if (head->next_binding == NULL) {
           // This is the only binding remove binding from hash table
           removefrom_hashtable(&function_hash_table, (void *)name);
@@ -564,6 +566,7 @@ GOTCHA_EXPORT enum gotcha_error_t gotcha_unwrap(const char *tool_name) {
         lookup_hashtable(&notfound_binding_table, (void *)name, (void **)&head);
     if (hash_result == 0) {
       if (head == binding) {
+        debug_printf(1, "Found function %s not yet wrapped by tool\n", name);
         if (head->next_binding == NULL) {
           // This is the only binding remove binding from hash table
           removefrom_hashtable(&notfound_binding_table, (void *)name);
@@ -576,6 +579,7 @@ GOTCHA_EXPORT enum gotcha_error_t gotcha_unwrap(const char *tool_name) {
       }
     }
   }
+  debug_printf(1, "Removing tool %s from list\n", tool_name);
   // Remove tool from our list
   remove_tool_from_list(tool_instance);
   reorder_tool(tool_instance);

--- a/test/dlopen/num2.c
+++ b/test/dlopen/num2.c
@@ -16,6 +16,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 extern void mark_had_error();
 extern int return_five();
 
-int return_four() { return 4; }
+int return_four() { return 6; }
 
 int test_return_five() { return return_five(); }

--- a/test/unit/gotcha_unit_tests.c
+++ b/test/unit/gotcha_unit_tests.c
@@ -153,6 +153,10 @@ START_TEST(symbol_wrap_test) {
   }
   tools = get_tool_list();
   ck_assert_msg((tools == NULL), "tools should not exists");
+  ck_assert_msg(gotcha_unwrap("internal_test_tool") == GOTCHA_SUCCESS,
+                "should be able to unwrap 'internal_test_tool' tool");
+  int y = simpleFunc();
+  ck_assert_msg((y == TESTING_LIB_RET_VAL), "no wrapping should occur");
 }
 END_TEST
 

--- a/test/unit/gotcha_unit_tests.c
+++ b/test/unit/gotcha_unit_tests.c
@@ -79,6 +79,10 @@ START_TEST(auto_tool_creation) {
   for (lib = _r_debug.r_map; lib != 0; lib = lib->l_next) {
     remove_library(lib);
   }
+  int result = gotcha_unwrap("dummy_tool_name");
+  ck_assert_msg(result == GOTCHA_INVALID_TOOL, "The tool should not be found.");
+  result = gotcha_unwrap("sample_autocreate_tool");
+  ck_assert_msg(result == GOTCHA_SUCCESS, "The tool should be found.");
 }
 END_TEST
 

--- a/test/unit/gotcha_unit_tests.c
+++ b/test/unit/gotcha_unit_tests.c
@@ -138,6 +138,10 @@ START_TEST(symbol_wrap_test) {
   ck_assert_msg((tools != NULL), "tools should exists");
   binds = get_tool_bindings(tools);
   ck_assert_msg((bindings != NULL), "should return tool's bindings");
+  ck_assert_msg(gotcha_unwrap("internal_test_tool") == GOTCHA_SUCCESS,
+                "should be able to unwrap 'internal_test_tool' tool");
+  int y = simpleFunc();
+  ck_assert_msg((y == TESTING_LIB_RET_VAL), "no wrapping should occur");
   gotcha_wrap(bindings, 1, "internal_test_tool2");
   ck_assert_msg((1), "should always pass");
   gotcha_wrap(bindings, 1, "internal_test_tool3");
@@ -153,10 +157,6 @@ START_TEST(symbol_wrap_test) {
   }
   tools = get_tool_list();
   ck_assert_msg((tools == NULL), "tools should not exists");
-  ck_assert_msg(gotcha_unwrap("internal_test_tool") == GOTCHA_SUCCESS,
-                "should be able to unwrap 'internal_test_tool' tool");
-  int y = simpleFunc();
-  ck_assert_msg((y == TESTING_LIB_RET_VAL), "no wrapping should occur");
 }
 END_TEST
 


### PR DESCRIPTION
Currently, users do not have a way to unwrap their bindings. This results in users freeing binding prematurely without disabling GOTCHA. This will allow users to manage tools wrapped.

The main logic is,

We look at function bindings on `function_hash_table` and `notfound_binding_table` tables.
If we find a binding of the tool we are unwrapping, then we move it to the next finding if available.
If the next binding does not exist, we remove the function binding.

We add test case with dlsym as well as function calls.