### PR TITLE
The docs need to pinned to spinx version 7.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -27,6 +27,6 @@ sphinx:
 # Optional but recommended, declare the Python requirements required
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#    install:
-#    - requirements: docs/requirements.txt
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
+sphinx<7.0.0
 sphinx-rtd-theme


### PR DESCRIPTION
The docs need a specific version of spinx. Tagging that fixes the docs build.