### PR TITLE
Fix potential invalid array access in gotcha_strnlen

### DIFF
--- a/src/libc_wrappers.c
+++ b/src/libc_wrappers.c
@@ -191,7 +191,7 @@ size_t gotcha_strlen(const char *s) {
 
 size_t gotcha_strnlen(const char *s, size_t max_length) {
   size_t i = 0;
-  for (i = 0; s[i] && i < max_length; i++)
+  for (i = 0; i < max_length && s[i]; i++)
     ;
   return i;
 }


### PR DESCRIPTION
Fixes potential invalid array access in `gotcha_strnlen`. See LLNL/Caliper#640