### PR TITLE
Remove empty nested dir that causes build error with FetchContent

### DIFF
--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -7,6 +7,15 @@ if (NOT TARGET gotcha)
   include(${CMAKE_CURRENT_LIST_DIR}/gotcha-targets.cmake)
 endif()
 
+if (TARGET gotcha)
+  set_property(TARGET gotcha APPEND PROPERTY
+    INTERFACE_INCLUDE_DIRECTORIES "${gotcha_INCLUDE_DIR}"
+  )
+  set_property(TARGET gotcha APPEND PROPERTY
+    INTERFACE_LINK_DIRECTORIES "${gotcha_LIBRARY_PATH}"
+  )
+endif ()
+
 set(gotcha_INCLUDE_DIRS ${gotcha_INCLUDE_DIR})
 set(gotcha_LIBRARIES gotcha)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,7 +36,11 @@ endif ()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
-install(TARGETS gotcha EXPORT gotcha-targets DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(TARGETS gotcha
+    EXPORT gotcha-targets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
 install(EXPORT gotcha-targets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/gotcha)
 
 if (GOTCHA_ENABLE_EXAMPLE)


### PR DESCRIPTION
This directory is causing error with FetchContent around automatic submodule handling.